### PR TITLE
Synchronize `EventSource.readyState` updates 

### DIFF
--- a/Sources/Sunday/NetworkRequestFactory.swift
+++ b/Sources/Sunday/NetworkRequestFactory.swift
@@ -78,7 +78,11 @@ public class NetworkRequestFactory: RequestFactory {
   }
   
   public func registerProblem(type: URL, problemType: Problem.Type) {
-    self.problemTypes[type.absoluteString] = problemType
+    registerProblem(type: type.absoluteString, problemType: problemType)
+  }
+  
+  public func registerProblem(type: String, problemType: Problem.Type) {
+    self.problemTypes[type] = problemType
   }
 
   public func request<B: Encodable>(

--- a/Sources/Sunday/RequestFactory.swift
+++ b/Sources/Sunday/RequestFactory.swift
@@ -17,6 +17,7 @@ public protocol RequestFactory {
   var baseURL: URI.Template { get }
   
   func registerProblem(type: URL, problemType: Problem.Type)
+  func registerProblem(type: String, problemType: Problem.Type)
   
   func request<B: Encodable>(method: HTTP.Method, pathTemplate: String,
                              pathParameters: Parameters?, queryParameters: Parameters?, body: B?,


### PR DESCRIPTION
Previously `readyState` was tested and updated at will. Which produced race conditions and could lead to a closed `EventSource`s continuously reopening.

All changes to `readyState` are now serialized via the dispatch queue. Also updates that aren't the result of an explicit call from external code are checked to ensure they don't re-open an already closed instance.