### PR TITLE
Generator interface updates

### DIFF
--- a/Sources/Sunday/AnyTextMediaTypeDecodable.swift
+++ b/Sources/Sunday/AnyTextMediaTypeDecodable.swift
@@ -1,0 +1,21 @@
+//
+//  AnyTextMediaTypeDecodable.swift
+//  Sunday
+//
+//  Copyright © 2018 Outfox, inc.
+//
+//
+//  Distributed under the MIT License, See LICENSE for details.
+//
+
+import Foundation
+
+
+public struct AnyTextMediaTypeDecodable {
+  public let decode: (TextMediaTypeDecoder, String) throws -> Any?
+
+  public static func erase<D : Decodable>(_ type: D.Type = D.self) -> AnyTextMediaTypeDecodable {
+    return AnyTextMediaTypeDecodable(decode: { try $0.decode(D.self, from: $1) })
+  }
+
+}

--- a/Sources/Sunday/CustomHeaderConvertible.swift
+++ b/Sources/Sunday/CustomHeaderConvertible.swift
@@ -1,0 +1,22 @@
+//
+//  CustomHeaderConvertible.swift
+//  
+//
+//  Created by Kevin Wooten on 5/21/21.
+//
+
+import Foundation
+
+
+protocol CustomHeaderConvertible {
+  var headerDescription: String { get }
+}
+
+
+/**
+ * Standard PathParameterConvertible types
+ */
+
+extension UUID: CustomHeaderConvertible {
+  var headerDescription: String { uuidString }
+}

--- a/Sources/Sunday/Errors.swift
+++ b/Sources/Sunday/Errors.swift
@@ -16,6 +16,7 @@ public enum RequestEncodingFailureReason {
   case noSupportedAcceptTypes([MediaType])
   case unsupportedContentType(MediaType)
   case serializationFailed(contentType: MediaType, error: Error?)
+  case unsupportedHeaderParameterValue(Any)
 }
 
 public enum ResponseDecodingFailureReason {

--- a/Sources/Sunday/HTTP.swift
+++ b/Sources/Sunday/HTTP.swift
@@ -123,6 +123,12 @@ public struct HTTP {
     .httpVersionNotSupported: "Http Version Not Supported",
   ]
 
+  public struct Header : Equatable {
+    var name: String
+    var value: String
+  }
+
+  public typealias HeaderList = [Header]
   public typealias Headers = [String: [String]]
   public typealias RawHeaders = [(name: String, value: Data)]
   public typealias Version = (major: Int, minor: Int)

--- a/Sources/Sunday/HeaderParameters.swift
+++ b/Sources/Sunday/HeaderParameters.swift
@@ -1,0 +1,48 @@
+//
+//  HeaderParameters.swift
+//  
+//
+//  Created by Kevin Wooten on 5/21/21.
+//
+
+import Foundation
+
+
+enum HeaderParameters {
+
+  static func encode(headers: [String: Any?]) throws -> HTTP.HeaderList{
+
+    let headersMultiMap =
+      try headers.compactMapValues { headerValue in
+        try headerValue.map { try encode(parameter: $0) }
+      }
+
+    return headersMultiMap.flatMap { name, values in
+      values.map { HTTP.Header(name: name, value: $0) }
+    }
+  }
+
+  private static func encode(parameter: Any) throws -> [String] {
+
+    if let array = parameter as? Array<Any> {
+      return try array.map { try encode(value: $0) }
+    }
+
+    return [try encode(value: parameter)]
+  }
+
+  private static func encode(value: Any) throws -> String {
+    switch value {
+
+    case let header as CustomHeaderConvertible:
+      return header.headerDescription
+
+    case let string as LosslessStringConvertible:
+      return string.description
+
+    default:
+      throw SundayError.requestEncodingFailed(reason: .unsupportedHeaderParameterValue(value))
+    }
+  }
+
+}

--- a/Sources/Sunday/MediaType.swift
+++ b/Sources/Sunday/MediaType.swift
@@ -223,7 +223,7 @@ public func ~= (pattern: MediaType, value: String) -> Bool {
 
 
 
-extension MediaType: CustomStringConvertible {
+extension MediaType: CustomStringConvertible, LosslessStringConvertible {
 
   public var description: String {
     return value

--- a/Sources/Sunday/NetworkRequestFactory.swift
+++ b/Sources/Sunday/NetworkRequestFactory.swift
@@ -353,8 +353,8 @@ public class NetworkRequestFactory: RequestFactory {
   public func eventStream<B, D>(
     method: HTTP.Method, pathTemplate: String, pathParameters: Parameters? = nil, queryParameters: Parameters? = nil,
     body: B?, contentTypes: [MediaType]? = nil, acceptTypes: [MediaType]? = nil, headers: Parameters? = nil,
-    eventTypes: [String : D.Type]
-  ) -> RequestEventPublisher<D> where B : Encodable, D : Decodable {
+    eventTypes: [String : AnyTextMediaTypeDecodable]
+  ) -> RequestEventPublisher<D> where B : Encodable {
     
     self.eventStream(eventTypes: eventTypes,
                      from: self.request(method: method,
@@ -367,7 +367,7 @@ public class NetworkRequestFactory: RequestFactory {
                                         headers: headers))
   }
 
-  public func eventStream<D: Decodable>(eventTypes: [String : D.Type], from request$: RequestPublisher) -> RequestEventPublisher<D> {
+  public func eventStream<D>(eventTypes: [String : AnyTextMediaTypeDecodable], from request$: RequestPublisher) -> RequestEventPublisher<D> {
     Deferred { [self] () -> AnyPublisher<D, Error> in
       do {
         

--- a/Sources/Sunday/NetworkRequestFactory.swift
+++ b/Sources/Sunday/NetworkRequestFactory.swift
@@ -87,7 +87,7 @@ public class NetworkRequestFactory: RequestFactory {
 
   public func request<B: Encodable>(
     method: HTTP.Method, pathTemplate: String, pathParameters: Parameters? = nil, queryParameters: Parameters? = nil,
-    body: B?, contentTypes: [MediaType]? = nil, acceptTypes: [MediaType]? = nil, headers: HTTP.Headers? = nil
+    body: B?, contentTypes: [MediaType]? = nil, acceptTypes: [MediaType]? = nil, headers: Parameters? = nil
   ) -> RequestPublisher {
     
     Deferred { [self] () -> AnyPublisher<URLRequest, Error> in
@@ -115,11 +115,13 @@ public class NetworkRequestFactory: RequestFactory {
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = method.rawValue
         
-        // Add headers
-        headers?.forEach { key, values in
-          values.forEach { value in
-            urlRequest.setValue(value, forHTTPHeaderField: key)
-          }
+        // Encode and add headers
+        if let headers = headers {
+
+          try HeaderParameters.encode(headers: headers)
+            .forEach { entry in
+              urlRequest.addValue(entry.value, forHTTPHeaderField: entry.name)
+            }
         }
         
         // Determine & add accept header
@@ -167,7 +169,7 @@ public class NetworkRequestFactory: RequestFactory {
 
   public func response<B: Encodable>(
     method: HTTP.Method, pathTemplate: String, pathParameters: Parameters? = nil, queryParameters: Parameters? = nil,
-    body: B?, contentTypes: [MediaType]? = nil, acceptTypes: [MediaType]? = nil, headers: HTTP.Headers? = nil
+    body: B?, contentTypes: [MediaType]? = nil, acceptTypes: [MediaType]? = nil, headers: Parameters? = nil
   ) -> RequestResponsePublisher {
     
     return request(method: method, pathTemplate: pathTemplate, pathParameters: pathParameters,
@@ -279,7 +281,7 @@ public class NetworkRequestFactory: RequestFactory {
 
   public func result<B: Encodable, D: Decodable>(
     method: HTTP.Method, pathTemplate: String, pathParameters: Parameters? = nil, queryParameters: Parameters? = nil,
-    body: B?, contentTypes: [MediaType]? = nil, acceptTypes: [MediaType]? = nil, headers: HTTP.Headers? = nil
+    body: B?, contentTypes: [MediaType]? = nil, acceptTypes: [MediaType]? = nil, headers: Parameters? = nil
   ) -> RequestResultPublisher<D> {
     
     return response(method: method,
@@ -309,7 +311,7 @@ public class NetworkRequestFactory: RequestFactory {
 
   public func result<B: Encodable>(
     method: HTTP.Method, pathTemplate: String, pathParameters: Parameters?, queryParameters: Parameters?,
-    body: B?, contentTypes: [MediaType]?, acceptTypes: [MediaType]?, headers: HTTP.Headers?
+    body: B?, contentTypes: [MediaType]?, acceptTypes: [MediaType]?, headers: Parameters?
   ) -> RequestCompletePublisher {
     
     return response(method: method,
@@ -325,7 +327,7 @@ public class NetworkRequestFactory: RequestFactory {
 
   public func eventSource<B>(
     method: HTTP.Method, pathTemplate: String, pathParameters: Parameters? = nil, queryParameters: Parameters? = nil,
-    body: B?, contentTypes: [MediaType]? = nil, acceptTypes: [MediaType]? = nil, headers: HTTP.Headers? = nil
+    body: B?, contentTypes: [MediaType]? = nil, acceptTypes: [MediaType]? = nil, headers: Parameters? = nil
   ) -> EventSource where B : Encodable {
     
     self.eventSource(from: self.request(method: method,
@@ -350,7 +352,7 @@ public class NetworkRequestFactory: RequestFactory {
 
   public func eventStream<B, D>(
     method: HTTP.Method, pathTemplate: String, pathParameters: Parameters? = nil, queryParameters: Parameters? = nil,
-    body: B?, contentTypes: [MediaType]? = nil, acceptTypes: [MediaType]? = nil, headers: HTTP.Headers? = nil,
+    body: B?, contentTypes: [MediaType]? = nil, acceptTypes: [MediaType]? = nil, headers: Parameters? = nil,
     eventTypes: [String : D.Type]
   ) -> RequestEventPublisher<D> where B : Encodable, D : Decodable {
     

--- a/Sources/Sunday/RequestFactory.swift
+++ b/Sources/Sunday/RequestFactory.swift
@@ -56,11 +56,11 @@ public protocol RequestFactory {
     headers: Parameters?
   ) -> EventSource
 
-  func eventStream<B: Encodable, D: Decodable>(
+  func eventStream<B: Encodable, D>(
     method: HTTP.Method, pathTemplate: String,
     pathParameters: Parameters?, queryParameters: Parameters?, body: B?,
     contentTypes: [MediaType]?, acceptTypes: [MediaType]?,
-    headers: Parameters?, eventTypes: [String: D.Type]
+    headers: Parameters?, eventTypes: [String: AnyTextMediaTypeDecodable]
   ) -> RequestEventPublisher<D>
 
   func close(cancelOutstandingRequests: Bool)

--- a/Sources/Sunday/RequestFactory.swift
+++ b/Sources/Sunday/RequestFactory.swift
@@ -19,37 +19,49 @@ public protocol RequestFactory {
   func registerProblem(type: URL, problemType: Problem.Type)
   func registerProblem(type: String, problemType: Problem.Type)
   
-  func request<B: Encodable>(method: HTTP.Method, pathTemplate: String,
-                             pathParameters: Parameters?, queryParameters: Parameters?, body: B?,
-                             contentTypes: [MediaType]?, acceptTypes: [MediaType]?,
-                             headers: HTTP.Headers?) -> RequestPublisher
+  func request<B: Encodable>(
+    method: HTTP.Method, pathTemplate: String,
+    pathParameters: Parameters?, queryParameters: Parameters?, body: B?,
+    contentTypes: [MediaType]?, acceptTypes: [MediaType]?,
+    headers: Parameters?
+  ) -> RequestPublisher
   
-  func response<B: Encodable>(method: HTTP.Method, pathTemplate: String,
-                              pathParameters: Parameters?, queryParameters: Parameters?, body: B?,
-                              contentTypes: [MediaType]?, acceptTypes: [MediaType]?,
-                              headers: HTTP.Headers?) -> RequestResponsePublisher
+  func response<B: Encodable>(
+    method: HTTP.Method, pathTemplate: String,
+    pathParameters: Parameters?, queryParameters: Parameters?, body: B?,
+    contentTypes: [MediaType]?, acceptTypes: [MediaType]?,
+    headers: Parameters?
+  ) -> RequestResponsePublisher
 
   func response(request: URLRequest) -> RequestResponsePublisher
 
-  func result<B: Encodable, D: Decodable>(method: HTTP.Method, pathTemplate: String,
-                                          pathParameters: Parameters?, queryParameters: Parameters?, body: B?,
-                                          contentTypes: [MediaType]?, acceptTypes: [MediaType]?,
-                                          headers: HTTP.Headers?) -> RequestResultPublisher<D>
+  func result<B: Encodable, D: Decodable>(
+    method: HTTP.Method, pathTemplate: String,
+    pathParameters: Parameters?, queryParameters: Parameters?, body: B?,
+    contentTypes: [MediaType]?, acceptTypes: [MediaType]?,
+    headers: Parameters?
+  ) -> RequestResultPublisher<D>
 
-  func result<B: Encodable>(method: HTTP.Method, pathTemplate: String,
-                            pathParameters: Parameters?, queryParameters: Parameters?, body: B?,
-                            contentTypes: [MediaType]?, acceptTypes: [MediaType]?,
-                            headers: HTTP.Headers?) -> RequestCompletePublisher
+  func result<B: Encodable>(
+    method: HTTP.Method, pathTemplate: String,
+    pathParameters: Parameters?, queryParameters: Parameters?, body: B?,
+    contentTypes: [MediaType]?, acceptTypes: [MediaType]?,
+    headers: Parameters?
+  ) -> RequestCompletePublisher
 
-  func eventSource<B: Encodable>(method: HTTP.Method, pathTemplate: String,
-                                 pathParameters: Parameters?, queryParameters: Parameters?, body: B?,
-                                 contentTypes: [MediaType]?, acceptTypes: [MediaType]?,
-                                 headers: HTTP.Headers?) -> EventSource
+  func eventSource<B: Encodable>(
+    method: HTTP.Method, pathTemplate: String,
+    pathParameters: Parameters?, queryParameters: Parameters?, body: B?,
+    contentTypes: [MediaType]?, acceptTypes: [MediaType]?,
+    headers: Parameters?
+  ) -> EventSource
 
-  func eventStream<B: Encodable, D: Decodable>(method: HTTP.Method, pathTemplate: String,
-                                               pathParameters: Parameters?, queryParameters: Parameters?, body: B?,
-                                               contentTypes: [MediaType]?, acceptTypes: [MediaType]?,
-                                               headers: HTTP.Headers?, eventTypes: [String: D.Type]) -> RequestEventPublisher<D>
+  func eventStream<B: Encodable, D: Decodable>(
+    method: HTTP.Method, pathTemplate: String,
+    pathParameters: Parameters?, queryParameters: Parameters?, body: B?,
+    contentTypes: [MediaType]?, acceptTypes: [MediaType]?,
+    headers: Parameters?, eventTypes: [String: D.Type]
+  ) -> RequestEventPublisher<D>
 
   func close(cancelOutstandingRequests: Bool)
 

--- a/Sources/Sunday/URITemplate.swift
+++ b/Sources/Sunday/URITemplate.swift
@@ -67,7 +67,7 @@ public extension URI {
           variables[variableName] = value.pathDescription
         case let value as VariableValue:
           variables[variableName] = value
-        case let value as CustomStringConvertible:
+        case let value as LosslessStringConvertible:
           variables[variableName] = value.description
         case nil:
           throw Error.missingParameterValue(name: variableName)

--- a/Sources/Sunday/URLRequests.swift
+++ b/Sources/Sunday/URLRequests.swift
@@ -36,11 +36,19 @@ public extension URLRequest {
     copy.timeoutInterval = timeoutInterval
     return copy
   }
-  
+
   func adding(httpHeaders: HTTP.Headers) -> URLRequest {
     var copy = self
     for (headerName, headerValues) in httpHeaders {
       headerValues.forEach { copy.addValue($0, forHTTPHeaderField: headerName) }
+    }
+    return copy
+  }
+
+  func adding(httpHeaders: HTTP.HeaderList) -> URLRequest {
+    var copy = self
+    for httpHeader in httpHeaders {
+      copy.addValue(httpHeader.value, forHTTPHeaderField: httpHeader.name)
     }
     return copy
   }

--- a/Tests/SundayTests/HeaderParametersTests.swift
+++ b/Tests/SundayTests/HeaderParametersTests.swift
@@ -1,0 +1,107 @@
+//
+//  HeaderParametersTests.swift
+//  Sunday
+//
+//  Copyright © 2018 Outfox, inc.
+//
+//
+//  Distributed under the MIT License, See LICENSE for details.
+//
+
+import Foundation
+import XCTest
+@testable import Sunday
+
+
+class HeaderParametersTests: XCTestCase {
+
+  func testEncodingArrayValues() throws {
+
+    let values = [MediaType.json, MediaType.cbor]
+
+    let headers = try HeaderParameters.encode(headers: [
+      "test": values
+    ])
+
+    XCTAssertEqual(headers, [
+                    HTTP.Header(name: "test", value: MediaType.json.value),
+                    HTTP.Header(name: "test", value: MediaType.cbor.value)]
+    )
+  }
+
+  func testEncodingStringValues() throws {
+
+    let headers = try HeaderParameters.encode(headers: ["test": ["header"]])
+
+    XCTAssertEqual(headers, [HTTP.Header(name: "test", value: "header")])
+  }
+
+  func testEncodingIntegerValues() throws {
+
+    let headers = try HeaderParameters.encode(headers: ["test": 1])
+
+    XCTAssertEqual(headers, [HTTP.Header(name: "test", value: "1")])
+  }
+
+  func testEncodingFloatingValues() throws {
+
+    let headers = try HeaderParameters.encode(headers: ["test": 123.456])
+
+    XCTAssertEqual(headers, [HTTP.Header(name: "test", value: "123.456")])
+  }
+
+  func testIgnoresNilValues() throws {
+
+    let headers = try HeaderParameters.encode(headers: ["test": nil])
+
+    XCTAssertEqual(headers, [])
+  }
+
+  func testCustomHeaderConvertibleValues() throws {
+
+    struct Tester : CustomHeaderConvertible {
+      var headerDescription: String { "abcd3f" }
+    }
+
+    let headers = try HeaderParameters.encode(headers: ["test": Tester()])
+
+    XCTAssertEqual(headers, [HTTP.Header(name: "test", value: "abcd3f")])
+  }
+
+  func testLosslessStringConvertibleValues() throws {
+
+    struct SpecialParam : LosslessStringConvertible {
+
+      let value: String
+
+      init() {
+        value = "special-string"
+      }
+
+      init?(_ description: String) {
+        value = description
+      }
+
+      var description: String {
+        value
+      }
+
+    }
+
+    let headers = try HeaderParameters.encode(headers: ["test": SpecialParam()])
+
+    XCTAssertEqual(headers, [HTTP.Header(name: "test", value: "special-string")])
+  }
+
+  func testFailsOnUnknownParameterTypes() throws {
+
+    struct Tester {
+      let value = "tester"
+    }
+
+    XCTAssertThrowsError(try HeaderParameters.encode(headers: ["test": Tester()])) { error in
+      XCTAssertTrue(error is SundayError)
+    }
+  }
+
+}

--- a/Tests/SundayTests/NetworkRequestFactoryTests.swift
+++ b/Tests/SundayTests/NetworkRequestFactoryTests.swift
@@ -88,12 +88,16 @@ class NetworkRequestFactoryTests: XCTestCase {
       requestFactory.request(method: .get,
                              pathTemplate: "/api",
                              body: Empty.none,
-                             headers: [HTTP.StdHeaders.authorization: ["Bearer 12345"]])
+                             headers: [
+                              HTTP.StdHeaders.authorization: ["Bearer 12345", "Bearer 67890"],
+                              HTTP.StdHeaders.accept: [MediaType.json, MediaType.cbor],
+                             ])
       .record()
     
     let request = try wait(for: request$.single, timeout: 1.0)
-    
-    XCTAssertEqual(request.value(forHTTPHeaderField: HTTP.StdHeaders.authorization), "Bearer 12345")
+
+    XCTAssertEqual(request.value(forHTTPHeaderField: HTTP.StdHeaders.authorization), "Bearer 12345,Bearer 67890")
+    XCTAssertEqual(request.value(forHTTPHeaderField: HTTP.StdHeaders.accept), "application/json,application/cbor")
   }
   
   func testAddsAcceptHeader() throws {

--- a/Tests/SundayTests/NetworkRequestFactoryTests.swift
+++ b/Tests/SundayTests/NetworkRequestFactoryTests.swift
@@ -903,7 +903,7 @@ class NetworkRequestFactoryTests: XCTestCase {
                                             pathParameters: nil, queryParameters: nil,
                                             body: Empty.none, contentTypes: [.json],
                                             acceptTypes: [.json], headers: nil,
-                                            eventTypes: ["test": TestEvent.self])
+                                            eventTypes: ["test": .erase(TestEvent.self)]) as RequestEventPublisher<TestEvent>
 
     let completeX = expectation(description: "complete received")
 

--- a/Tests/SundayTests/URITemplatesTests.swift
+++ b/Tests/SundayTests/URITemplatesTests.swift
@@ -103,12 +103,22 @@ class URITemplatesTests: XCTestCase {
     )
   }
   
-  func testCustomStringConvertibleAreSerializedCorrectly() {
+  func testLosslessStringConvertibleAreSerializedCorrectly() {
     
-    struct SpecialParam : CustomStringConvertible {
-      
+    struct SpecialParam : LosslessStringConvertible {
+
+      let value: String
+
+      init() {
+        value = "special-string"
+      }
+
+      init?(_ description: String) {
+        value = description
+      }
+
       var description: String {
-        "special-string"
+        value
       }
       
     }
@@ -130,8 +140,8 @@ class URITemplatesTests: XCTestCase {
     XCTAssertEqual(template.format, "http://example.com/{id}")
     
     XCTAssertEqual(
-      try template.complete(parameters: ["id": ["test": 1]]).absoluteString.removingPercentEncoding,
-      "http://example.com/[\"test\": 1]"
+      try template.complete(parameters: ["id": ["test": "1"]]).absoluteString.removingPercentEncoding,
+      "http://example.com/test,1"
     )
   }
   


### PR DESCRIPTION
### Headers
All methods of `RequestFactory` that accept a `headers` parameter have been switched to a map of optional `Any` (aka `Sunday.Parameters`) as values; the same type as path and query parameters. Sunday encodes `CustomHeaderConvertible` and `LosslessStringConvertible` values along with arrays of those values. This better matches what modeling language descriptions allow.

### Event Stream Event Types
The `RequestFactory.eventStream` method requires a map of event types via its `eventTypes` parameter. The type of this parameter has changed to be a map of type erasures that allow decoding. This change was to allow the return value of the method to be anything, including `Any`; specifically it is not required to be a `Decodable` type.  

This change only effects the return type of the `eventStream` method and each type passed to the `eventTypes` map must be a `Decodable` type so that it can be properly erased.