### PR TITLE
Easy configuration of global `NetworkSession` timeouts & more `URLSessionConfiguration` convenience

### DIFF
--- a/Sources/Sunday/NetworkSession.swift
+++ b/Sources/Sunday/NetworkSession.swift
@@ -38,6 +38,19 @@ public class NetworkSession {
     delegate.owner = self
   }
 
+  public func copy(
+    configuration: URLSessionConfiguration? = nil,
+    serverTrustPolicyManager: ServerTrustPolicyManager? = nil,
+    delegate externalDelegate: URLSessionDelegate? = nil
+  ) -> NetworkSession {
+
+    return NetworkSession(
+      configuration: configuration ?? self.session.configuration,
+      serverTrustPolicyManager: serverTrustPolicyManager ?? self.serverTrustPolicyManager,
+      delegate: externalDelegate ?? self.delegate.delegate
+    )
+  }
+
   public typealias DataTaskPublisher = URLSession.DataTaskPublisher
 
   public func dataTaskPublisher(for request: URLRequest) -> DataTaskPublisher {

--- a/Sources/Sunday/URLSessionConfigurations.swift
+++ b/Sources/Sunday/URLSessionConfigurations.swift
@@ -19,19 +19,19 @@ import Foundation
 
 public extension URLSessionConfiguration {
 
-  static let restTimeoutIntervalForRequestDefault = TimeInterval(15)
-  static let restTimeoutIntervalForResourceDefault = TimeInterval(60)
+  static var restTimeoutIntervalForRequestDefault = TimeInterval(15)
+  static var restTimeoutIntervalForResourceDefault = TimeInterval(60)
 
   static func rest(
     from config: URLSessionConfiguration = .default,
-    requestTimeout: TimeInterval? = nil,
-    resourceTimeout: TimeInterval? = nil
+    requestTimeout: TimeInterval = restTimeoutIntervalForRequestDefault,
+    resourceTimeout: TimeInterval = restTimeoutIntervalForResourceDefault
   ) -> URLSessionConfiguration {
 
     config.networkServiceType = .default
     config.httpShouldUsePipelining = true
-    config.timeoutIntervalForRequest = requestTimeout ?? restTimeoutIntervalForRequestDefault
-    config.timeoutIntervalForResource = resourceTimeout ?? restTimeoutIntervalForResourceDefault
+    config.timeoutIntervalForRequest = requestTimeout
+    config.timeoutIntervalForResource = resourceTimeout
     config.waitsForConnectivity = true
     config.allowsExpensiveNetworkAccess = true
     config.allowsConstrainedNetworkAccess = true
@@ -42,6 +42,35 @@ public extension URLSessionConfiguration {
 
   static func rest(from config: URLSessionConfiguration = .default, timeout: TimeInterval) -> URLSessionConfiguration {
     return Self.rest(from: config, requestTimeout: timeout, resourceTimeout: timeout)
+  }
+
+
+  static var eventsTimeoutIntervalForRequestDefault = TimeInterval(180)
+  static var eventsTimeoutIntervalForResourceDefault = TimeInterval(600)
+
+  static func events(
+    from config: URLSessionConfiguration = .ephemeral,
+    requestTimeout: TimeInterval = eventsTimeoutIntervalForRequestDefault,
+    resourceTimeout: TimeInterval = eventsTimeoutIntervalForResourceDefault
+  ) -> URLSessionConfiguration {
+
+    config.networkServiceType = .background
+    config.httpShouldUsePipelining = true
+    config.timeoutIntervalForRequest = requestTimeout
+    config.timeoutIntervalForResource = resourceTimeout
+    config.waitsForConnectivity = true
+    config.allowsExpensiveNetworkAccess = true
+    config.allowsConstrainedNetworkAccess = true
+    config.allowsCellularAccess = true
+
+    return config
+  }
+
+  static func events(
+    from config: URLSessionConfiguration = .default,
+    timeout: TimeInterval
+  ) -> URLSessionConfiguration {
+    return Self.events(from: config, requestTimeout: timeout, resourceTimeout: timeout)
   }
 
 }

--- a/Tests/SundayTests/NetworkRequestFactoryTests.swift
+++ b/Tests/SundayTests/NetworkRequestFactoryTests.swift
@@ -1016,24 +1016,4 @@ class NetworkRequestFactoryTests: XCTestCase {
     waitForExpectations(timeout: 2.0, handler: nil)
   }
 
-  func testFluent() {
-
-    let factory = NetworkRequestFactory(baseURL: "http://example.com", sessionConfiguration: .default)
-
-    let restConfig = URLSessionConfiguration.rest()
-    let restFactory = factory.with(sessionConfiguration: restConfig)
-
-    XCTAssertEqual(restFactory.session.session.configuration, restConfig)
-  }
-
-  func testFluent2() {
-
-    let factory = NetworkRequestFactory(baseURL: "http://example.com", sessionConfiguration: .default)
-
-    let restSession = NetworkSession(configuration: .rest())
-    let restFactory = factory.with(session: restSession)
-
-    XCTAssertEqual(restFactory.session.session.configuration, restSession.session.configuration)
-  }
-
 }


### PR DESCRIPTION
Fixes #1

### NetworkRequestFactory configuratoin
`NetworkRequestSession.init` now accepts an `eventSession` parameter that is used solely when creating requests for `EventSource` & `EventPublusher` instances..  The parameter defaults to `nil` in which case it is coped from the standard `session` parameter. When copying the regular session it uses the new `URLSessionConfiguration.events()` convenience factory (see below).

### URLSessionConfiguration for “events”
Since Server-Sent Event requests have special requirements (e.g. long timeouts) a convenience extension factory method `events()` has been added. It creates a configuration sutiable for SSE streams.

### Global defaults
All of the defaults used by the `URLSessionConfiguration` extension factoires (both `rest()` and `events()`) now have configurable default values for easy global configuration.