### PR TITLE
Update package definition and dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ build-test-tvos:
 build-test-watchos:
 	$(call buildtest,watchOS,platform=watchOS Simulator$(comma)name=Apple Watch Series 7 (45mm))
 
-build-test-all: build-test-macos build-test-ios build-test-tvos
+build-test-all: build-test-macos build-test-ios build-test-tvos build-test-watchos
 
 format:	
 	swiftformat --config .swiftformat Sources/ Tests/

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.4
 
 import PackageDescription
 
@@ -23,8 +23,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/outfoxx/PotentCodables.git", .upToNextMinor(from: "2.3.0")),
     .package(url: "https://github.com/sharplet/Regex.git", .upToNextMinor(from: "2.1.0")),
-    .package(url: "https://github.com/SwiftScream/URITemplate.git", .upToNextMinor(from: "2.1.0")),
-    .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0")
+    .package(url: "https://github.com/SwiftScream/URITemplate.git", .upToNextMinor(from: "2.1.0"))
   ],
   targets: [
     .target(
@@ -50,3 +49,10 @@ let package = Package(
     ),
   ]
 )
+
+#if swift(>=5.6)
+  // Add the documentation compiler plugin if possible
+  package.dependencies.append(
+    .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0")
+  )
+#endif

--- a/Package.swift
+++ b/Package.swift
@@ -21,10 +21,10 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(url: "https://github.com/outfoxx/PotentCodables.git", from: "2.0.0"),
-    .package(url: "https://github.com/sharplet/Regex.git", from: "2.1.0"),
-    .package(url: "https://github.com/SwiftScream/URITemplate.git", from: "2.1.0"),
-    .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
+    .package(url: "https://github.com/outfoxx/PotentCodables.git", .upToNextMinor(from: "2.3.0")),
+    .package(url: "https://github.com/sharplet/Regex.git", .upToNextMinor(from: "2.1.0")),
+    .package(url: "https://github.com/SwiftScream/URITemplate.git", .upToNextMinor(from: "2.1.0")),
+    .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0")
   ],
   targets: [
     .target(

--- a/Sources/Sunday/ServerTrustPolicyManager.swift
+++ b/Sources/Sunday/ServerTrustPolicyManager.swift
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-//  swiftlint:disable function_body_length
-
 import Foundation
 
 


### PR DESCRIPTION
* Use 5.4 tools and conditionally include docc plugin for 5.6
* Use upToNextMinor for dependencies
