### PR TITLE
Fix DocC publish workflows

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,79 +1,87 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "BigInt",
-        "repositoryURL": "https://github.com/attaswift/BigInt.git",
-        "state": {
-          "branch": null,
-          "revision": "e07e00fa1fd435143a2dcf8b7eec9a7710b2fdfe",
-          "version": "5.7.0"
-        }
-      },
-      {
-        "package": "Float16",
-        "repositoryURL": "https://github.com/SusanDoggie/Float16.git",
-        "state": {
-          "branch": null,
-          "revision": "936ae66adccf1c91bcaeeb9c0cddde78a13695c3",
-          "version": "1.1.1"
-        }
-      },
-      {
-        "package": "PotentCodables",
-        "repositoryURL": "https://github.com/outfoxx/PotentCodables.git",
-        "state": {
-          "branch": null,
-          "revision": "be0593a39fa3c8203dd10bdbad3803435517c100",
-          "version": "3.5.3"
-        }
-      },
-      {
-        "package": "Regex",
-        "repositoryURL": "https://github.com/sharplet/Regex.git",
-        "state": {
-          "branch": null,
-          "revision": "76c2b73d4281d77fc3118391877efd1bf972f515",
-          "version": "2.1.1"
-        }
-      },
-      {
-        "package": "swift-collections",
-        "repositoryURL": "https://github.com/apple/swift-collections.git",
-        "state": {
-          "branch": null,
-          "revision": "fea17c02d767f46b23070fdfdacc28a03a39232a",
-          "version": "1.5.1"
-        }
-      },
-      {
-        "package": "SwiftDocCPlugin",
-        "repositoryURL": "https://github.com/apple/swift-docc-plugin",
-        "state": {
-          "branch": null,
-          "revision": "3303b164430d9a7055ba484c8ead67a52f7b74f6",
-          "version": "1.0.0"
-        }
-      },
-      {
-        "package": "swift-numerics",
-        "repositoryURL": "https://github.com/apple/swift-numerics",
-        "state": {
-          "branch": null,
-          "revision": "0a5bc04095a675662cf24757cc0640aa2204253b",
-          "version": "1.0.2"
-        }
-      },
-      {
-        "package": "ScreamURITemplate",
-        "repositoryURL": "https://github.com/SwiftScream/URITemplate.git",
-        "state": {
-          "branch": null,
-          "revision": "3a6acca43ac7aa3f58474e6c8f686809b3660d6a",
-          "version": "4.0.0"
-        }
+  "originHash" : "583b7f6ea33bf8b10b7837559c01067347837b0afca11331ab95722d377a3223",
+  "pins" : [
+    {
+      "identity" : "bigint",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/attaswift/BigInt.git",
+      "state" : {
+        "revision" : "e07e00fa1fd435143a2dcf8b7eec9a7710b2fdfe",
+        "version" : "5.7.0"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "float16",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SusanDoggie/Float16.git",
+      "state" : {
+        "revision" : "936ae66adccf1c91bcaeeb9c0cddde78a13695c3",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "potentcodables",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/outfoxx/PotentCodables.git",
+      "state" : {
+        "revision" : "be0593a39fa3c8203dd10bdbad3803435517c100",
+        "version" : "3.5.3"
+      }
+    },
+    {
+      "identity" : "regex",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sharplet/Regex.git",
+      "state" : {
+        "revision" : "76c2b73d4281d77fc3118391877efd1bf972f515",
+        "version" : "2.1.1"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "fea17c02d767f46b23070fdfdacc28a03a39232a",
+        "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-plugin",
+      "state" : {
+        "revision" : "647c708be89f834fa6a6d4945442793a77ddf5b6",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics",
+      "state" : {
+        "revision" : "0a5bc04095a675662cf24757cc0640aa2204253b",
+        "version" : "1.0.2"
+      }
+    },
+    {
+      "identity" : "uritemplate",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SwiftScream/URITemplate.git",
+      "state" : {
+        "revision" : "3a6acca43ac7aa3f58474e6c8f686809b3660d6a",
+        "version" : "4.0.0"
+      }
+    }
+  ],
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -53,6 +53,6 @@ let package = Package(
 #if swift(>=5.6)
   // Add the documentation compiler plugin if possible
   package.dependencies.append(
-    .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0")
+    .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.5.0")
   )
 #endif

--- a/Sources/Sunday/Patching.swift
+++ b/Sources/Sunday/Patching.swift
@@ -28,10 +28,10 @@ public protocol AnyPatchOp: Codable, Sendable {
 
 // MARK: UpdateOp
 
-/// Wrapper that represents a limited patch operation support seting/merging, not changing the target property in the
-/// target object. Thedelete operation is **not** supported by ``UpdateOp``.
+/// Wrapper that represents a limited patch operation supporting setting/merging, or not changing the target property in
+/// the target object. The delete operation is **not** supported by ``UpdateOp``.
 ///
-/// - Note A "no change" operation is represented by the ``nil`` value.
+/// - Note: A "no change" operation is represented by the `nil` value.
 ///
 /// - SeeAlso ``PatchOp``
 ///
@@ -88,9 +88,9 @@ public enum UpdateOp<Value: Codable & Sendable>: AnyPatchOp, Codable {
 
 // MARK: PatchOp
 
-/// A full patch operation support seting/merging, deleting or not changing the target property in the target object.
+/// A full patch operation supporting setting/merging, deleting or not changing the target property in the target object.
 ///
-/// - Note A "no change" operation is represented by the ``nil`` value.
+/// - Note: A "no change" operation is represented by the `nil` value.
 /// - SeeAlso ``UpdateOp``
 ///
 public enum PatchOp<Value: Codable & Sendable>: AnyPatchOp, Codable {

--- a/Sources/Sunday/URITemplate.swift
+++ b/Sources/Sunday/URITemplate.swift
@@ -65,6 +65,7 @@ public extension URI {
     ///   - relative: Template for the relative portion of the complete URL
     ///   - parameters: Parameters for the format; these take precedence
     ///     when encountering duplicates
+    ///   - encoders: Encoders used to format path parameter values.
     public func complete(
       relative: String = "",
       parameters: Parameters = [:],

--- a/Sources/Sunday/URLSessionTransport.swift
+++ b/Sources/Sunday/URLSessionTransport.swift
@@ -61,11 +61,18 @@ public final class URLSessionTransport: Transport, Sendable {
   /// Creates a URLSession-backed transport.
   ///
   /// - Parameters:
+  ///   - baseURL: Base URI template used to resolve request paths.
   ///   - session: Session used for non-streaming requests and responses.
   ///   - eventSession: Session used for server-sent event streams. Pass `session` when event streams
   ///     must use the same delegate or session behavior. Pass a session created with
   ///     `.sunday(configuration: .events(...))` or an equivalent configuration when SSE-specific
   ///     timeout and resource settings are required.
+  ///   - adapter: Optional adapter applied to generated requests.
+  ///   - requestQueue: Queue used to schedule request preparation work.
+  ///   - mediaTypeEncoders: Encoders used to serialize request bodies.
+  ///   - mediaTypeDecoders: Decoders used to deserialize response bodies.
+  ///   - eventRequestTimeoutInterval: Timeout used for server-sent event requests.
+  ///   - pathEncoders: Encoders used to format path parameter values.
   public init(
     baseURL: URI.Template,
     session: URLSession,


### PR DESCRIPTION
Updates SwiftDocCPlugin to 1.5.0 so publish documentation runs use a plugin compatible with the macOS 26 DocC toolchain instead of emitting the removed --index option. Refreshes Package.resolved and fixes DocC documentation warnings surfaced by the updated plugin. Verified with swift package generate-documentation for Sunday and swift test.