### PR TITLE
Add streaming request body support

### DIFF
--- a/Sources/Sunday/AsyncSequenceInputStream.swift
+++ b/Sources/Sunday/AsyncSequenceInputStream.swift
@@ -67,7 +67,6 @@ private final class AsyncSequenceInputStreamOwner<S>: NSObject, StreamDelegate, 
   private let bytes: S
   private let state = Mutex(State.idle)
   private let runLoop = Mutex<RunLoopReference?>(nil)
-  private let runLoopReady = DispatchSemaphore(value: 0)
 
   init(outputStream: OutputStream, bytes: S) {
     self.outputStream = outputStream
@@ -77,7 +76,12 @@ private final class AsyncSequenceInputStreamOwner<S>: NSObject, StreamDelegate, 
 
   func start() {
     let task = Task.detached { [self] in
-      startRunLoop()
+      await startRunLoop()
+
+      guard !Task.isCancelled, !isClosed else {
+        return
+      }
+
       outputStream.open()
       defer { close(cancelTask: false) }
 
@@ -198,25 +202,25 @@ private final class AsyncSequenceInputStreamOwner<S>: NSObject, StreamDelegate, 
     }
   }
 
-  private func startRunLoop() {
-    Thread.detachNewThread { [self] in
-      runLoop.withLock { runLoop in
-        runLoop = RunLoopReference(CFRunLoopGetCurrent())
+  private func startRunLoop() async {
+    await withCheckedContinuation { continuation in
+      Thread.detachNewThread { [self] in
+        runLoop.withLock { runLoop in
+          runLoop = RunLoopReference(CFRunLoopGetCurrent())
+        }
+
+        outputStream.delegate = self
+        outputStream.schedule(in: .current, forMode: .default)
+        continuation.resume()
+
+        while !isClosed {
+          CFRunLoopRun()
+        }
+
+        outputStream.remove(from: .current, forMode: .default)
+        outputStream.delegate = nil
       }
-
-      outputStream.delegate = self
-      outputStream.schedule(in: .current, forMode: .default)
-      runLoopReady.signal()
-
-      while !isClosed {
-        CFRunLoopRun()
-      }
-
-      outputStream.remove(from: .current, forMode: .default)
-      outputStream.delegate = nil
     }
-
-    runLoopReady.wait()
   }
 
   private func close(cancelTask: Bool) {

--- a/Sources/Sunday/AsyncSequenceInputStream.swift
+++ b/Sources/Sunday/AsyncSequenceInputStream.swift
@@ -45,27 +45,41 @@ enum AsyncSequenceInputStream {
 
 
 // OutputStream is not Sendable, but this owner keeps it private to one writer task and only exposes cancellation.
-private final class AsyncSequenceInputStreamOwner<S>: @unchecked Sendable where S: AsyncSequence & Sendable, S.Element == Data {
+private final class AsyncSequenceInputStreamOwner<S>: NSObject, StreamDelegate, @unchecked Sendable where S: AsyncSequence & Sendable, S.Element == Data {
 
   private enum State: Sendable {
     case idle
-    case running(Task<Void, Never>)
+    case running(Task<Void, Never>, CheckedContinuation<Void, any Error>?)
     case closed
+  }
+
+  private final class RunLoopReference: @unchecked Sendable {
+
+    let value: CFRunLoop
+
+    init(_ value: CFRunLoop) {
+      self.value = value
+    }
+
   }
 
   private let outputStream: OutputStream
   private let bytes: S
   private let state = Mutex(State.idle)
+  private let runLoop = Mutex<RunLoopReference?>(nil)
+  private let runLoopReady = DispatchSemaphore(value: 0)
 
   init(outputStream: OutputStream, bytes: S) {
     self.outputStream = outputStream
     self.bytes = bytes
+    super.init()
   }
 
   func start() {
     let task = Task.detached { [self] in
+      startRunLoop()
       outputStream.open()
-      defer { outputStream.close() }
+      defer { close(cancelTask: false) }
 
       do {
         for try await chunk in bytes {
@@ -83,7 +97,7 @@ private final class AsyncSequenceInputStreamOwner<S>: @unchecked Sendable where 
     state.withLock { state in
       switch state {
       case .idle:
-        state = .running(task)
+        state = .running(task, nil)
       case .running:
         task.cancel()
       case .closed:
@@ -93,13 +107,18 @@ private final class AsyncSequenceInputStreamOwner<S>: @unchecked Sendable where 
   }
 
   func cancel() {
-    state.withLock { state in
-      if case .running(let task) = state {
-        task.cancel()
-      }
-      state = .closed
+    close(cancelTask: true)
+  }
+
+  func stream(_ aStream: Stream, handle eventCode: Stream.Event) {
+    switch eventCode {
+    case .hasSpaceAvailable:
+      resumeWaitingWriter()
+    case .errorOccurred, .endEncountered:
+      resumeWaitingWriter(throwing: outputStream.streamError ?? SundayError.requestEncodingFailed(reason: .streamCreationFailed))
+    default:
+      break
     }
-    outputStream.close()
   }
 
   private func write(_ data: Data) async throws {
@@ -121,11 +140,118 @@ private final class AsyncSequenceInputStreamOwner<S>: @unchecked Sendable where 
         remaining -= written
       }
       else if written == 0 {
-        try await Task.sleep(nanoseconds: 5_000_000)
+        try await waitForSpace()
       }
       else {
         throw outputStream.streamError ?? SundayError.requestEncodingFailed(reason: .streamCreationFailed)
       }
+    }
+  }
+
+  private func waitForSpace() async throws {
+    try await withTaskCancellationHandler {
+      try await withCheckedThrowingContinuation { continuation in
+        let immediateResult: Result<Void, any Error>? =
+          state.withLock { state in
+            switch state {
+            case .idle, .closed:
+              return .failure(CancellationError())
+            case .running(_, .some):
+              return .failure(SundayError.requestEncodingFailed(reason: .streamCreationFailed))
+            case .running(let task, nil):
+              if outputStream.hasSpaceAvailable {
+                return .success(())
+              }
+              state = .running(task, continuation)
+              return nil
+            }
+          }
+
+        if let immediateResult {
+          continuation.resume(with: immediateResult)
+        }
+      }
+    } onCancel: {
+      resumeWaitingWriter(throwing: CancellationError())
+    }
+  }
+
+  private func resumeWaitingWriter(throwing error: (any Error)? = nil) {
+    let continuation =
+      state.withLock { state -> CheckedContinuation<Void, any Error>? in
+        switch state {
+        case .idle, .closed:
+          return nil
+        case .running(_, nil):
+          return nil
+        case .running(let task, .some(let continuation)):
+          state = .running(task, nil)
+          return continuation
+        }
+      }
+
+    if let error {
+      continuation?.resume(throwing: error)
+    }
+    else {
+      continuation?.resume()
+    }
+  }
+
+  private func startRunLoop() {
+    Thread.detachNewThread { [self] in
+      runLoop.withLock { runLoop in
+        runLoop = RunLoopReference(CFRunLoopGetCurrent())
+      }
+
+      outputStream.delegate = self
+      outputStream.schedule(in: .current, forMode: .default)
+      runLoopReady.signal()
+
+      while !isClosed {
+        CFRunLoopRun()
+      }
+
+      outputStream.remove(from: .current, forMode: .default)
+      outputStream.delegate = nil
+    }
+
+    runLoopReady.wait()
+  }
+
+  private func close(cancelTask: Bool) {
+    let continuation =
+      state.withLock { state -> CheckedContinuation<Void, any Error>? in
+        switch state {
+        case .idle:
+          state = .closed
+          outputStream.close()
+          return nil
+        case .running(let task, let continuation):
+          if cancelTask {
+            task.cancel()
+          }
+          state = .closed
+          outputStream.close()
+          return continuation
+        case .closed:
+          return nil
+        }
+      }
+
+    continuation?.resume(throwing: CancellationError())
+
+    if let runLoop = runLoop.withLock({ $0 }) {
+      CFRunLoopStop(runLoop.value)
+    }
+  }
+
+  private var isClosed: Bool {
+    state.withLock { state in
+      if case .closed = state {
+        return true
+      }
+      return false
     }
   }
 

--- a/Sources/Sunday/AsyncSequenceInputStream.swift
+++ b/Sources/Sunday/AsyncSequenceInputStream.swift
@@ -53,20 +53,9 @@ private final class AsyncSequenceInputStreamOwner<S>: NSObject, StreamDelegate, 
     case closed
   }
 
-  private final class RunLoopReference: @unchecked Sendable {
-
-    let value: CFRunLoop
-
-    init(_ value: CFRunLoop) {
-      self.value = value
-    }
-
-  }
-
   private let outputStream: OutputStream
   private let bytes: S
   private let state = Mutex(State.idle)
-  private let runLoop = Mutex<RunLoopReference?>(nil)
 
   init(outputStream: OutputStream, bytes: S) {
     self.outputStream = outputStream
@@ -76,7 +65,7 @@ private final class AsyncSequenceInputStreamOwner<S>: NSObject, StreamDelegate, 
 
   func start() {
     let task = Task.detached { [self] in
-      await startRunLoop()
+      await scheduleOutputStream()
 
       guard !Task.isCancelled, !isClosed else {
         return
@@ -202,24 +191,11 @@ private final class AsyncSequenceInputStreamOwner<S>: NSObject, StreamDelegate, 
     }
   }
 
-  private func startRunLoop() async {
-    await withCheckedContinuation { continuation in
-      Thread.detachNewThread { [self] in
-        runLoop.withLock { runLoop in
-          runLoop = RunLoopReference(CFRunLoopGetCurrent())
-        }
+  private func scheduleOutputStream() async {
+    await AsyncSequenceInputStreamRunLoop.shared.schedule(outputStream, delegate: self)
 
-        outputStream.delegate = self
-        outputStream.schedule(in: .current, forMode: .default)
-        continuation.resume()
-
-        while !isClosed {
-          CFRunLoopRun()
-        }
-
-        outputStream.remove(from: .current, forMode: .default)
-        outputStream.delegate = nil
-      }
+    if isClosed {
+      AsyncSequenceInputStreamRunLoop.shared.unschedule(outputStream)
     }
   }
 
@@ -245,9 +221,7 @@ private final class AsyncSequenceInputStreamOwner<S>: NSObject, StreamDelegate, 
 
     continuation?.resume(throwing: CancellationError())
 
-    if let runLoop = runLoop.withLock({ $0 }) {
-      CFRunLoopStop(runLoop.value)
-    }
+    AsyncSequenceInputStreamRunLoop.shared.unschedule(outputStream)
   }
 
   private var isClosed: Bool {
@@ -261,6 +235,120 @@ private final class AsyncSequenceInputStreamOwner<S>: NSObject, StreamDelegate, 
 
   deinit {
     cancel()
+  }
+
+}
+
+
+private final class AsyncSequenceInputStreamRunLoop: @unchecked Sendable {
+
+  static let shared = AsyncSequenceInputStreamRunLoop()
+
+  private struct State: Sendable {
+    var isStarted = false
+    var runLoop: RunLoopReference?
+    var waiters: [CheckedContinuation<RunLoopReference, Never>] = []
+  }
+
+  private final class RunLoopReference: @unchecked Sendable {
+
+    let value: CFRunLoop
+
+    init(_ value: CFRunLoop) {
+      self.value = value
+    }
+
+  }
+
+  private let state = Mutex(State())
+
+  func schedule(_ outputStream: OutputStream, delegate: StreamDelegate) async {
+    let runLoop = await sharedRunLoop()
+
+    await withCheckedContinuation { continuation in
+      CFRunLoopPerformBlock(runLoop.value, CFRunLoopMode.defaultMode.rawValue) {
+        outputStream.delegate = delegate
+        outputStream.schedule(in: .current, forMode: .default)
+        continuation.resume()
+      }
+      CFRunLoopWakeUp(runLoop.value)
+    }
+  }
+
+  func unschedule(_ outputStream: OutputStream) {
+    guard let runLoop = state.withLock({ $0.runLoop }) else {
+      return
+    }
+
+    CFRunLoopPerformBlock(runLoop.value, CFRunLoopMode.defaultMode.rawValue) {
+      outputStream.remove(from: .current, forMode: .default)
+      outputStream.delegate = nil
+    }
+    CFRunLoopWakeUp(runLoop.value)
+  }
+
+  private func sharedRunLoop() async -> RunLoopReference {
+    await withCheckedContinuation { continuation in
+      var shouldStartThread = false
+      let immediateRunLoop =
+        state.withLock { state -> RunLoopReference? in
+          if let runLoop = state.runLoop {
+            return runLoop
+          }
+
+          state.waiters.append(continuation)
+          if !state.isStarted {
+            state.isStarted = true
+            shouldStartThread = true
+          }
+          return nil
+        }
+
+      if let immediateRunLoop {
+        continuation.resume(returning: immediateRunLoop)
+      }
+      else if shouldStartThread {
+        startThread()
+      }
+    }
+  }
+
+  private func startThread() {
+    Thread.detachNewThread { [self] in
+      var sourceContext = CFRunLoopSourceContext(
+        version: 0,
+        info: nil,
+        retain: nil,
+        release: nil,
+        copyDescription: nil,
+        equal: nil,
+        hash: nil,
+        schedule: nil,
+        cancel: nil,
+        perform: nil
+      )
+      guard let source = CFRunLoopSourceCreate(nil, 0, &sourceContext) else {
+        fatalError("Could not create shared input stream run loop source")
+      }
+
+      guard let runLoop = CFRunLoopGetCurrent() else {
+        fatalError("Could not get shared input stream run loop")
+      }
+      CFRunLoopAddSource(runLoop, source, CFRunLoopMode.defaultMode)
+
+      let reference = RunLoopReference(runLoop)
+      let waiters =
+        state.withLock { state in
+          state.runLoop = reference
+          let waiters = state.waiters
+          state.waiters.removeAll()
+          return waiters
+        }
+
+      waiters.forEach { $0.resume(returning: reference) }
+
+      CFRunLoopRun()
+    }
   }
 
 }

--- a/Sources/Sunday/AsyncSequenceInputStream.swift
+++ b/Sources/Sunday/AsyncSequenceInputStream.swift
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2021 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+import Synchronization
+
+
+enum AsyncSequenceInputStream {
+
+  static func makeInputStream<S>(
+    bytes: S
+  ) throws -> InputStream where S: AsyncSequence & Sendable, S.Element == Data {
+
+    var inputStream: InputStream?
+    var outputStream: OutputStream?
+    Stream.getBoundStreams(
+      withBufferSize: 64 * 1024,
+      inputStream: &inputStream,
+      outputStream: &outputStream
+    )
+
+    guard let inputStream, let outputStream else {
+      throw SundayError.requestEncodingFailed(reason: .streamCreationFailed)
+    }
+
+    let owner = AsyncSequenceInputStreamOwner(outputStream: outputStream, bytes: bytes)
+
+    return RetainedInputStream(inputStream: inputStream, owner: owner)
+  }
+
+}
+
+
+// OutputStream is not Sendable, but this owner keeps it private to one writer task and only exposes cancellation.
+private final class AsyncSequenceInputStreamOwner<S>: @unchecked Sendable where S: AsyncSequence & Sendable, S.Element == Data {
+
+  private enum State: Sendable {
+    case idle
+    case running(Task<Void, Never>)
+    case closed
+  }
+
+  private let outputStream: OutputStream
+  private let bytes: S
+  private let state = Mutex(State.idle)
+
+  init(outputStream: OutputStream, bytes: S) {
+    self.outputStream = outputStream
+    self.bytes = bytes
+  }
+
+  func start() {
+    let task = Task.detached { [self] in
+      outputStream.open()
+      defer { outputStream.close() }
+
+      do {
+        for try await chunk in bytes {
+          try await write(chunk)
+          if Task.isCancelled {
+            return
+          }
+        }
+      }
+      catch {
+        return
+      }
+    }
+
+    state.withLock { state in
+      switch state {
+      case .idle:
+        state = .running(task)
+      case .running:
+        task.cancel()
+      case .closed:
+        task.cancel()
+      }
+    }
+  }
+
+  func cancel() {
+    state.withLock { state in
+      if case .running(let task) = state {
+        task.cancel()
+      }
+      state = .closed
+    }
+    outputStream.close()
+  }
+
+  private func write(_ data: Data) async throws {
+    var remaining = data.count
+    var offset = 0
+
+    while remaining > 0 {
+      let written =
+        data.withUnsafeBytes { bytes in
+          guard let baseAddress = bytes.bindMemory(to: UInt8.self).baseAddress else {
+            return 0
+          }
+
+          return outputStream.write(baseAddress + offset, maxLength: remaining)
+        }
+
+      if written > 0 {
+        offset += written
+        remaining -= written
+      }
+      else if written == 0 {
+        try await Task.sleep(nanoseconds: 5_000_000)
+      }
+      else {
+        throw outputStream.streamError ?? SundayError.requestEncodingFailed(reason: .streamCreationFailed)
+      }
+    }
+  }
+
+  deinit {
+    cancel()
+  }
+
+}
+
+
+private final class RetainedInputStream: InputStream, @unchecked Sendable {
+
+  private let inputStream: InputStream
+  private let startOwner: @Sendable () -> Void
+  private let cancelOwner: @Sendable () -> Void
+
+  init<S>(inputStream: InputStream, owner: AsyncSequenceInputStreamOwner<S>) {
+    self.inputStream = inputStream
+    self.startOwner = { owner.start() }
+    self.cancelOwner = { owner.cancel() }
+    super.init(data: Data())
+  }
+
+  override var streamStatus: Stream.Status {
+    inputStream.streamStatus
+  }
+
+  override var streamError: (any Error)? {
+    inputStream.streamError
+  }
+
+  override var hasBytesAvailable: Bool {
+    inputStream.hasBytesAvailable
+  }
+
+  override var delegate: (any StreamDelegate)? {
+    get {
+      inputStream.delegate
+    }
+    set {
+      inputStream.delegate = newValue
+    }
+  }
+
+  override func open() {
+    inputStream.open()
+    startOwner()
+  }
+
+  override func close() {
+    cancelOwner()
+    inputStream.close()
+  }
+
+  override func read(_ buffer: UnsafeMutablePointer<UInt8>, maxLength len: Int) -> Int {
+    inputStream.read(buffer, maxLength: len)
+  }
+
+  override func getBuffer(
+    _ buffer: UnsafeMutablePointer<UnsafeMutablePointer<UInt8>?>,
+    length len: UnsafeMutablePointer<Int>
+  ) -> Bool {
+    inputStream.getBuffer(buffer, length: len)
+  }
+
+  override func property(forKey key: Stream.PropertyKey) -> Any? {
+    inputStream.property(forKey: key)
+  }
+
+  override func setProperty(_ property: Any?, forKey key: Stream.PropertyKey) -> Bool {
+    inputStream.setProperty(property, forKey: key)
+  }
+
+  override func schedule(in aRunLoop: RunLoop, forMode mode: RunLoop.Mode) {
+    inputStream.schedule(in: aRunLoop, forMode: mode)
+  }
+
+  override func remove(from aRunLoop: RunLoop, forMode mode: RunLoop.Mode) {
+    inputStream.remove(from: aRunLoop, forMode: mode)
+  }
+
+  deinit {
+    cancelOwner()
+  }
+
+}

--- a/Sources/Sunday/Errors.swift
+++ b/Sources/Sunday/Errors.swift
@@ -23,6 +23,7 @@ public enum RequestEncodingFailureReason: Sendable {
   case noSupportedAcceptTypes([MediaType])
   case unsupportedContentType(MediaType)
   case serializationFailed(contentType: MediaType, error: Error?)
+  case streamCreationFailed
   case unsupportedHeaderParameterValue(any Sendable)
 }
 
@@ -85,6 +86,8 @@ extension RequestEncodingFailureReason: CustomStringConvertible {
       return "Unsupported Content-Type: type=\(contentType)"
     case .serializationFailed(contentType: let contentType, error: let error):
       return "Serialization Failed\(error.map { ": \($0)" } ?? ""): content-type=\(contentType)"
+    case .streamCreationFailed:
+      return "Stream Creation Failed"
     case .unsupportedHeaderParameterValue(let value):
       return "Unsupported Header Value: value=\(String(describing: value))"
     }

--- a/Sources/Sunday/Operation.swift
+++ b/Sources/Sunday/Operation.swift
@@ -18,7 +18,7 @@ import Foundation
 
 
 /// Describes a generated HTTP operation request.
-public struct OperationSpec<RequestBody: Encodable & Sendable>: Sendable {
+public struct OperationSpec<RequestBody: Sendable>: Sendable {
 
   /// The HTTP method to use.
   public let method: HTTP.Method
@@ -32,7 +32,7 @@ public struct OperationSpec<RequestBody: Encodable & Sendable>: Sendable {
   /// Query parameter values for the operation.
   public let queryParameters: Parameters?
 
-  /// Encodable request body value.
+  /// Request body value.
   public let body: RequestBody?
 
   /// Candidate media types for encoding `body`.
@@ -44,6 +44,12 @@ public struct OperationSpec<RequestBody: Encodable & Sendable>: Sendable {
   /// HTTP header parameter values for the operation.
   public let headers: Parameters?
 
+  private let prepareRequestBody: @Sendable (
+    RequestBody?,
+    [MediaType]?,
+    MediaTypeEncoders
+  ) throws -> PreparedRequestBody?
+
   /// Creates an operation request specification.
   public init(
     method: HTTP.Method,
@@ -53,7 +59,12 @@ public struct OperationSpec<RequestBody: Encodable & Sendable>: Sendable {
     body: RequestBody? = nil,
     contentTypes: [MediaType]? = nil,
     acceptTypes: [MediaType]? = nil,
-    headers: Parameters? = nil
+    headers: Parameters? = nil,
+    prepareBody: @escaping @Sendable (
+      RequestBody?,
+      [MediaType]?,
+      MediaTypeEncoders
+    ) throws -> PreparedRequestBody?
   ) {
     self.method = method
     self.pathTemplate = pathTemplate
@@ -63,6 +74,81 @@ public struct OperationSpec<RequestBody: Encodable & Sendable>: Sendable {
     self.contentTypes = contentTypes
     self.acceptTypes = acceptTypes
     self.headers = headers
+    self.prepareRequestBody = prepareBody
+  }
+
+  func prepareBody(mediaTypeEncoders: MediaTypeEncoders) throws -> PreparedRequestBody? {
+    try prepareRequestBody(body, contentTypes, mediaTypeEncoders)
+  }
+
+}
+
+
+public extension OperationSpec where RequestBody: Encodable {
+
+  /// Creates an operation request specification with an encodable request body.
+  init(
+    method: HTTP.Method,
+    pathTemplate: String,
+    pathParameters: Parameters? = nil,
+    queryParameters: Parameters? = nil,
+    body: RequestBody? = nil,
+    contentTypes: [MediaType]? = nil,
+    acceptTypes: [MediaType]? = nil,
+    headers: Parameters? = nil
+  ) {
+    self.init(
+      method: method,
+      pathTemplate: pathTemplate,
+      pathParameters: pathParameters,
+      queryParameters: queryParameters,
+      body: body,
+      contentTypes: contentTypes,
+      acceptTypes: acceptTypes,
+      headers: headers
+    ) { body, contentTypes, mediaTypeEncoders in
+      guard let body else {
+        return nil
+      }
+      guard let contentType = contentTypes?.first(where: { mediaTypeEncoders.supports(for: $0) }) else {
+        throw SundayError.requestEncodingFailed(reason: .noSupportedContentTypes(contentTypes ?? []))
+      }
+      let data = try mediaTypeEncoders.find(for: contentType).encode(body)
+      return .data(data, contentType: contentType)
+    }
+  }
+
+}
+
+
+public extension OperationSpec where RequestBody == StreamingBody {
+
+  /// Creates an operation request specification with a streaming request body.
+  static func streaming(
+    method: HTTP.Method,
+    pathTemplate: String,
+    pathParameters: Parameters? = nil,
+    queryParameters: Parameters? = nil,
+    body: StreamingBody? = nil,
+    contentTypes: [MediaType]? = nil,
+    acceptTypes: [MediaType]? = nil,
+    headers: Parameters? = nil
+  ) -> OperationSpec<StreamingBody> {
+    OperationSpec<StreamingBody>(
+      method: method,
+      pathTemplate: pathTemplate,
+      pathParameters: pathParameters,
+      queryParameters: queryParameters,
+      body: body,
+      contentTypes: contentTypes,
+      acceptTypes: acceptTypes,
+      headers: headers
+    ) { body, contentTypes, _ in
+      guard let body else {
+        return nil
+      }
+      return .stream(body, contentType: contentTypes?.first)
+    }
   }
 
 }
@@ -90,7 +176,7 @@ public struct NilifySpec: Sendable {
 
 
 /// A generated operation that can be executed or converted into a native transport request.
-public struct Operation<RequestBody: Encodable & Sendable, ResponseBody: Sendable, TransportType: Transport>: Sendable {
+public struct Operation<RequestBody: Sendable, ResponseBody: Sendable, TransportType: Transport>: Sendable {
 
   /// The generated operation request specification.
   public let spec: OperationSpec<RequestBody>
@@ -108,30 +194,25 @@ public struct Operation<RequestBody: Encodable & Sendable, ResponseBody: Sendabl
 
   /// Builds a native transport request without executing it.
   public func transportRequest() async throws -> TransportType.Request {
-    try await transport.transportRequest(
-      method: spec.method,
-      pathTemplate: spec.pathTemplate,
-      pathParameters: spec.pathParameters,
-      queryParameters: spec.queryParameters,
-      body: spec.body,
-      contentTypes: spec.contentTypes,
-      acceptTypes: spec.acceptTypes,
-      headers: spec.headers
-    )
+    try await transport.transportRequest(spec: spec)
   }
 
   /// Executes the operation and returns the native transport response.
   public func transportResponse() async throws -> TransportType.Response {
-    let request = try await transportRequest()
-    return try await transport.transportResponse(request: request)
+    try await transport.transportResponse(spec: spec)
   }
 
 }
 
 
+/// An operation whose request body is streamed by the transport.
+public typealias StreamingOperation<ResponseBody: Sendable, TransportType: Transport> =
+  Operation<StreamingBody, ResponseBody, TransportType>
+
+
 /// A generated operation that can execute select problems as nil responses.
 public struct NilableOperation<
-  RequestBody: Encodable & Sendable,
+  RequestBody: Sendable,
   ResponseBody: Sendable,
   TransportType: Transport
 >: Sendable {
@@ -173,30 +254,12 @@ extension Operation where ResponseBody: Decodable {
 
   /// Executes the operation and decodes the response value.
   public func execute() async throws -> ResponseBody {
-    try await transport.result(
-      method: spec.method,
-      pathTemplate: spec.pathTemplate,
-      pathParameters: spec.pathParameters,
-      queryParameters: spec.queryParameters,
-      body: spec.body,
-      contentTypes: spec.contentTypes,
-      acceptTypes: spec.acceptTypes,
-      headers: spec.headers
-    )
+    try await transport.result(spec: spec)
   }
 
   /// Executes the operation and returns the decoded value with the HTTP response.
   public func response() async throws -> OperationResponse<ResponseBody> {
-    try await transport.response(
-      method: spec.method,
-      pathTemplate: spec.pathTemplate,
-      pathParameters: spec.pathParameters,
-      queryParameters: spec.queryParameters,
-      body: spec.body,
-      contentTypes: spec.contentTypes,
-      acceptTypes: spec.acceptTypes,
-      headers: spec.headers
-    )
+    try await transport.response(spec: spec)
   }
 
 }
@@ -239,30 +302,12 @@ extension Operation where ResponseBody == Void {
 
   /// Executes the operation and decodes the response value.
   public func execute() async throws {
-    try await transport.result(
-      method: spec.method,
-      pathTemplate: spec.pathTemplate,
-      pathParameters: spec.pathParameters,
-      queryParameters: spec.queryParameters,
-      body: spec.body,
-      contentTypes: spec.contentTypes,
-      acceptTypes: spec.acceptTypes,
-      headers: spec.headers
-    )
+    try await transport.result(spec: spec)
   }
 
   /// Executes the operation and returns the decoded value with the HTTP response.
   public func response() async throws -> OperationResponse<Void> {
-    try await transport.response(
-      method: spec.method,
-      pathTemplate: spec.pathTemplate,
-      pathParameters: spec.pathParameters,
-      queryParameters: spec.queryParameters,
-      body: spec.body,
-      contentTypes: spec.contentTypes,
-      acceptTypes: spec.acceptTypes,
-      headers: spec.headers
-    )
+    try await transport.response(spec: spec)
   }
 
 }

--- a/Sources/Sunday/PreparedRequestBody.swift
+++ b/Sources/Sunday/PreparedRequestBody.swift
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+
+/// A request body prepared for a native transport request.
+public enum PreparedRequestBody: Sendable {
+
+  /// A fully encoded request body.
+  case data(Data, contentType: MediaType)
+
+  /// A streaming request body.
+  case stream(StreamingBody, contentType: MediaType?)
+
+  var contentType: MediaType? {
+    switch self {
+    case .data(_, let contentType):
+      return contentType
+    case .stream(_, let contentType):
+      return contentType
+    }
+  }
+
+}

--- a/Sources/Sunday/StreamingBody.swift
+++ b/Sources/Sunday/StreamingBody.swift
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+
+/// A request body that can be streamed by the underlying transport.
+public struct StreamingBody: Sendable {
+
+  private enum Source: Sendable {
+    case file(URL)
+    case stream(@Sendable () throws -> InputStream)
+    case bytes(@Sendable () throws -> InputStream)
+  }
+
+  private let source: Source
+
+  /// Creates a streaming body from a fresh input stream factory.
+  ///
+  /// The factory is called each time the body is attached to a transport request.
+  /// This allows redirects, authentication retries, and repeated operation executions
+  /// to receive a new stream instead of reusing a consumed stream.
+  public init(stream makeBodyStream: @escaping @Sendable () throws -> InputStream) {
+    self.source = .stream(makeBodyStream)
+  }
+
+  /// Creates a streaming body from a local file URL.
+  public static func file(_ url: URL) -> StreamingBody {
+    StreamingBody(source: .file(url))
+  }
+
+  /// Creates a streaming body from an async byte sequence factory.
+  public static func bytes<S>(
+    _ makeBytes: @escaping @Sendable () -> S
+  ) -> StreamingBody where S: AsyncSequence & Sendable, S.Element == Data {
+    StreamingBody(source: .bytes {
+      try AsyncSequenceInputStream.makeInputStream(bytes: makeBytes())
+    })
+  }
+
+  func makeInputStream() throws -> InputStream {
+    switch source {
+    case .file(let url):
+      guard let stream = InputStream(url: url) else {
+        throw SundayError.requestEncodingFailed(reason: .streamCreationFailed)
+      }
+      return stream
+    case .stream(let makeStream):
+      return try makeStream()
+    case .bytes(let makeStream):
+      return try makeStream()
+    }
+  }
+
+  private init(source: Source) {
+    self.source = source
+  }
+
+}

--- a/Sources/Sunday/StreamingBodyRequestProperty.swift
+++ b/Sources/Sunday/StreamingBodyRequestProperty.swift
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+let streamingBodyRequestPropertyKey = "io.outfoxx.sunday.streamingBody"
+
+
+final class StreamingBodyRequestProperty {
+
+  let body: StreamingBody
+
+  init(body: StreamingBody) {
+    self.body = body
+  }
+
+}

--- a/Sources/Sunday/StreamingBodyRequestProperty.swift
+++ b/Sources/Sunday/StreamingBodyRequestProperty.swift
@@ -14,15 +14,31 @@
  * limitations under the License.
  */
 
+import Synchronization
+
+
 let streamingBodyRequestPropertyKey = "io.outfoxx.sunday.streamingBody"
 
 
-final class StreamingBodyRequestProperty {
+final class StreamingBodyRequestProperty: Sendable {
 
   let body: StreamingBody
+  private let replayError = Mutex<Error?>(nil)
 
   init(body: StreamingBody) {
     self.body = body
+  }
+
+  var recordedReplayError: Error? {
+    replayError.withLock { $0 }
+  }
+
+  func recordReplayError(_ error: Error) {
+    replayError.withLock { currentError in
+      if currentError == nil {
+        currentError = error
+      }
+    }
   }
 
 }

--- a/Sources/Sunday/Transport.swift
+++ b/Sources/Sunday/Transport.swift
@@ -37,75 +37,208 @@ public protocol Transport: Sendable {
   func registerProblem<P: Problem>(type: String, problemType: P.Type)
 
   /// Builds a native transport request without executing it.
-  func transportRequest<B: Encodable>(
-    method: HTTP.Method, pathTemplate: String,
-    pathParameters: Parameters?, queryParameters: Parameters?, body: B?,
-    contentTypes: [MediaType]?, acceptTypes: [MediaType]?,
-    headers: Parameters?
-  ) async throws -> Request
+  func transportRequest<RequestBody: Sendable>(spec: OperationSpec<RequestBody>) async throws -> Request
 
   /// Executes the operation request and returns the native transport response.
-  func transportResponse<B: Encodable>(
-    method: HTTP.Method, pathTemplate: String,
-    pathParameters: Parameters?, queryParameters: Parameters?, body: B?,
-    contentTypes: [MediaType]?, acceptTypes: [MediaType]?,
-    headers: Parameters?
-  ) async throws -> Response
+  func transportResponse<RequestBody: Sendable>(spec: OperationSpec<RequestBody>) async throws -> Response
 
   /// Executes a native transport request and returns the native transport response.
   func transportResponse(request: Request) async throws -> Response
 
   /// Executes the operation request and returns a decoded result with response metadata.
-  func response<B: Encodable, D: Decodable>(
-    method: HTTP.Method, pathTemplate: String,
-    pathParameters: Parameters?, queryParameters: Parameters?, body: B?,
-    contentTypes: [MediaType]?, acceptTypes: [MediaType]?,
-    headers: Parameters?
+  func response<RequestBody: Sendable, D: Decodable>(
+    spec: OperationSpec<RequestBody>
   ) async throws -> OperationResponse<D>
 
   /// Executes the operation request and returns a void result with response metadata.
-  func response<B: Encodable>(
-    method: HTTP.Method, pathTemplate: String,
-    pathParameters: Parameters?, queryParameters: Parameters?, body: B?,
-    contentTypes: [MediaType]?, acceptTypes: [MediaType]?,
-    headers: Parameters?
+  func response<RequestBody: Sendable>(
+    spec: OperationSpec<RequestBody>
   ) async throws -> OperationResponse<Void>
 
   /// Executes the operation request and returns only the decoded result.
-  func result<B: Encodable, D: Decodable>(
-    method: HTTP.Method, pathTemplate: String,
-    pathParameters: Parameters?, queryParameters: Parameters?, body: B?,
-    contentTypes: [MediaType]?, acceptTypes: [MediaType]?,
-    headers: Parameters?
+  func result<RequestBody: Sendable, D: Decodable>(
+    spec: OperationSpec<RequestBody>
   ) async throws -> D
 
   /// Executes the operation request and validates a void result.
-  func result<B: Encodable>(
-    method: HTTP.Method, pathTemplate: String,
-    pathParameters: Parameters?, queryParameters: Parameters?, body: B?,
-    contentTypes: [MediaType]?, acceptTypes: [MediaType]?,
-    headers: Parameters?
+  func result<RequestBody: Sendable>(
+    spec: OperationSpec<RequestBody>
   ) async throws
 
   /// Creates an event source for the operation request.
-  func eventSource<B: Encodable & Sendable>(
-    method: HTTP.Method, pathTemplate: String,
-    pathParameters: Parameters?, queryParameters: Parameters?, body: B?,
-    contentTypes: [MediaType]?, acceptTypes: [MediaType]?,
-    headers: Parameters?
-  ) -> EventSource
+  func eventSource<RequestBody: Sendable>(spec: OperationSpec<RequestBody>) -> EventSource
 
   /// Creates an event stream for the operation request.
-  func eventStream<B: Encodable & Sendable, D>(
-    method: HTTP.Method, pathTemplate: String,
-    pathParameters: Parameters?, queryParameters: Parameters?, body: B?,
-    contentTypes: [MediaType]?, acceptTypes: [MediaType]?,
-    headers: Parameters?,
+  func eventStream<RequestBody: Sendable, D>(
+    spec: OperationSpec<RequestBody>,
     decoder: @escaping @Sendable (TextMediaTypeDecoder, String?, String?, String, Logger) throws -> D?
   ) -> AsyncStream<D>
 
   /// Closes any transport resources.
   func close(cancelOutstandingRequests: Bool)
+
+}
+// swiftlint:enable function_parameter_count
+
+
+// swiftlint:disable function_parameter_count
+public extension Transport {
+
+  /// Builds a native transport request without executing it.
+  func transportRequest<B: Encodable & Sendable>(
+    method: HTTP.Method, pathTemplate: String,
+    pathParameters: Parameters? = nil, queryParameters: Parameters? = nil, body: B?,
+    contentTypes: [MediaType]? = nil, acceptTypes: [MediaType]? = nil,
+    headers: Parameters? = nil
+  ) async throws -> Request {
+    try await transportRequest(spec: OperationSpec(
+      method: method,
+      pathTemplate: pathTemplate,
+      pathParameters: pathParameters,
+      queryParameters: queryParameters,
+      body: body,
+      contentTypes: contentTypes,
+      acceptTypes: acceptTypes,
+      headers: headers
+    ))
+  }
+
+  /// Executes the operation request and returns the native transport response.
+  func transportResponse<B: Encodable & Sendable>(
+    method: HTTP.Method, pathTemplate: String,
+    pathParameters: Parameters? = nil, queryParameters: Parameters? = nil, body: B?,
+    contentTypes: [MediaType]? = nil, acceptTypes: [MediaType]? = nil,
+    headers: Parameters? = nil
+  ) async throws -> Response {
+    try await transportResponse(spec: OperationSpec(
+      method: method,
+      pathTemplate: pathTemplate,
+      pathParameters: pathParameters,
+      queryParameters: queryParameters,
+      body: body,
+      contentTypes: contentTypes,
+      acceptTypes: acceptTypes,
+      headers: headers
+    ))
+  }
+
+  /// Executes the operation request and returns a decoded result with response metadata.
+  func response<B: Encodable & Sendable, D: Decodable>(
+    method: HTTP.Method, pathTemplate: String,
+    pathParameters: Parameters? = nil, queryParameters: Parameters? = nil, body: B?,
+    contentTypes: [MediaType]? = nil, acceptTypes: [MediaType]? = nil,
+    headers: Parameters? = nil
+  ) async throws -> OperationResponse<D> {
+    try await response(spec: OperationSpec(
+      method: method,
+      pathTemplate: pathTemplate,
+      pathParameters: pathParameters,
+      queryParameters: queryParameters,
+      body: body,
+      contentTypes: contentTypes,
+      acceptTypes: acceptTypes,
+      headers: headers
+    ))
+  }
+
+  /// Executes the operation request and returns a void result with response metadata.
+  func response<B: Encodable & Sendable>(
+    method: HTTP.Method, pathTemplate: String,
+    pathParameters: Parameters? = nil, queryParameters: Parameters? = nil, body: B?,
+    contentTypes: [MediaType]? = nil, acceptTypes: [MediaType]? = nil,
+    headers: Parameters? = nil
+  ) async throws -> OperationResponse<Void> {
+    try await response(spec: OperationSpec(
+      method: method,
+      pathTemplate: pathTemplate,
+      pathParameters: pathParameters,
+      queryParameters: queryParameters,
+      body: body,
+      contentTypes: contentTypes,
+      acceptTypes: acceptTypes,
+      headers: headers
+    ))
+  }
+
+  /// Executes the operation request and returns only the decoded result.
+  func result<B: Encodable & Sendable, D: Decodable>(
+    method: HTTP.Method, pathTemplate: String,
+    pathParameters: Parameters? = nil, queryParameters: Parameters? = nil, body: B?,
+    contentTypes: [MediaType]? = nil, acceptTypes: [MediaType]? = nil,
+    headers: Parameters? = nil
+  ) async throws -> D {
+    try await result(spec: OperationSpec(
+      method: method,
+      pathTemplate: pathTemplate,
+      pathParameters: pathParameters,
+      queryParameters: queryParameters,
+      body: body,
+      contentTypes: contentTypes,
+      acceptTypes: acceptTypes,
+      headers: headers
+    ))
+  }
+
+  /// Executes the operation request and validates a void result.
+  func result<B: Encodable & Sendable>(
+    method: HTTP.Method, pathTemplate: String,
+    pathParameters: Parameters? = nil, queryParameters: Parameters? = nil, body: B?,
+    contentTypes: [MediaType]? = nil, acceptTypes: [MediaType]? = nil,
+    headers: Parameters? = nil
+  ) async throws {
+    try await result(spec: OperationSpec(
+      method: method,
+      pathTemplate: pathTemplate,
+      pathParameters: pathParameters,
+      queryParameters: queryParameters,
+      body: body,
+      contentTypes: contentTypes,
+      acceptTypes: acceptTypes,
+      headers: headers
+    ))
+  }
+
+  /// Creates an event source for the operation request.
+  func eventSource<B: Encodable & Sendable>(
+    method: HTTP.Method, pathTemplate: String,
+    pathParameters: Parameters? = nil, queryParameters: Parameters? = nil, body: B?,
+    contentTypes: [MediaType]? = nil, acceptTypes: [MediaType]? = nil,
+    headers: Parameters? = nil
+  ) -> EventSource {
+    eventSource(spec: OperationSpec(
+      method: method,
+      pathTemplate: pathTemplate,
+      pathParameters: pathParameters,
+      queryParameters: queryParameters,
+      body: body,
+      contentTypes: contentTypes,
+      acceptTypes: acceptTypes,
+      headers: headers
+    ))
+  }
+
+  /// Creates an event stream for the operation request.
+  func eventStream<B: Encodable & Sendable, D>(
+    method: HTTP.Method, pathTemplate: String,
+    pathParameters: Parameters? = nil, queryParameters: Parameters? = nil, body: B?,
+    contentTypes: [MediaType]? = nil, acceptTypes: [MediaType]? = nil,
+    headers: Parameters? = nil,
+    decoder: @escaping @Sendable (TextMediaTypeDecoder, String?, String?, String, Logger) throws -> D?
+  ) -> AsyncStream<D> {
+    eventStream(
+      spec: OperationSpec(
+        method: method,
+        pathTemplate: pathTemplate,
+        pathParameters: pathParameters,
+        queryParameters: queryParameters,
+        body: body,
+        contentTypes: contentTypes,
+        acceptTypes: acceptTypes,
+        headers: headers
+      ),
+      decoder: decoder
+    )
+  }
 
 }
 // swiftlint:enable function_parameter_count

--- a/Sources/Sunday/URLSession+Sunday.swift
+++ b/Sources/Sunday/URLSession+Sunday.swift
@@ -36,13 +36,39 @@ public extension URLSession {
 
   func validatedData(for request: URLRequest) async throws -> (Data?, HTTPURLResponse) {
 
-    let (data, response) = try await data(for: request)
+    if
+      URLProtocol.property(
+        forKey: streamingBodyRequestPropertyKey,
+        in: request
+      ) is StreamingBodyRequestProperty
+    {
+      let (responseBody, response) = try await streamingData(for: request)
+      return try validate(responseBody: responseBody, response: response)
+    }
 
+    let (responseBody, response) = try await data(for: request)
+
+    return try validate(responseBody: responseBody, response: response)
+  }
+
+  private func streamingData(for request: URLRequest) async throws -> (Data, URLResponse) {
+    let (bytes, response) = try await bytes(for: request)
+    var data = Data()
+    data.reserveCapacity(16 * 1024)
+
+    for try await byte in bytes {
+      data.append(byte)
+    }
+
+    return (data, response)
+  }
+
+  private func validate(responseBody: Data, response: URLResponse) throws -> (Data?, HTTPURLResponse) {
     guard let httpResponse = response as? HTTPURLResponse else {
       throw URLError(.badServerResponse)
     }
 
-    let responseData = data.isEmpty ? nil : data
+    let responseData = responseBody.isEmpty ? nil : responseBody
 
     if 400 ..< 600 ~= httpResponse.statusCode {
       throw SundayError.responseValidationFailed(reason: .unacceptableStatusCode(

--- a/Sources/Sunday/URLSession+Sunday.swift
+++ b/Sources/Sunday/URLSession+Sunday.swift
@@ -36,31 +36,9 @@ public extension URLSession {
 
   func validatedData(for request: URLRequest) async throws -> (Data?, HTTPURLResponse) {
 
-    if
-      URLProtocol.property(
-        forKey: streamingBodyRequestPropertyKey,
-        in: request
-      ) is StreamingBodyRequestProperty
-    {
-      let (responseBody, response) = try await streamingData(for: request)
-      return try validate(responseBody: responseBody, response: response)
-    }
-
     let (responseBody, response) = try await data(for: request)
 
     return try validate(responseBody: responseBody, response: response)
-  }
-
-  private func streamingData(for request: URLRequest) async throws -> (Data, URLResponse) {
-    let (bytes, response) = try await bytes(for: request)
-    var data = Data()
-    data.reserveCapacity(16 * 1024)
-
-    for try await byte in bytes {
-      data.append(byte)
-    }
-
-    return (data, response)
   }
 
   private func validate(responseBody: Data, response: URLResponse) throws -> (Data?, HTTPURLResponse) {

--- a/Sources/Sunday/URLSession+Sunday.swift
+++ b/Sources/Sunday/URLSession+Sunday.swift
@@ -23,13 +23,9 @@ public extension URLSession {
     configuration: URLSessionConfiguration,
     serverTrustPolicyManager: ServerTrustPolicyManager? = nil
   ) -> URLSession {
-    guard let serverTrustPolicyManager else {
-      return URLSession(configuration: configuration)
-    }
-
     return URLSession(
       configuration: configuration,
-      delegate: ServerTrustPolicyDelegate(serverTrustPolicyManager: serverTrustPolicyManager),
+      delegate: SundayURLSessionDelegate(serverTrustPolicyManager: serverTrustPolicyManager),
       delegateQueue: nil
     )
   }
@@ -266,12 +262,31 @@ struct DataEventBuffer {
 }
 
 
-private final class ServerTrustPolicyDelegate: NSObject, URLSessionTaskDelegate {
+private final class SundayURLSessionDelegate: NSObject, URLSessionTaskDelegate {
 
   private let serverTrustPolicyManager: ServerTrustPolicyManager?
 
   init(serverTrustPolicyManager: ServerTrustPolicyManager?) {
     self.serverTrustPolicyManager = serverTrustPolicyManager
+  }
+
+  public func urlSession(
+    _ session: URLSession,
+    task: URLSessionTask,
+    needNewBodyStream completionHandler: @escaping @Sendable (InputStream?) -> Void
+  ) {
+    guard
+      let request = task.currentRequest ?? task.originalRequest,
+      let property = URLProtocol.property(
+        forKey: streamingBodyRequestPropertyKey,
+        in: request
+      ) as? StreamingBodyRequestProperty
+    else {
+      completionHandler(nil)
+      return
+    }
+
+    completionHandler(try? property.body.makeInputStream())
   }
 
   public func urlSession(

--- a/Sources/Sunday/URLSession+Sunday.swift
+++ b/Sources/Sunday/URLSession+Sunday.swift
@@ -32,7 +32,17 @@ public extension URLSession {
 
   func validatedData(for request: URLRequest) async throws -> (Data?, HTTPURLResponse) {
 
-    let (responseBody, response) = try await data(for: request)
+    let responseBody: Data
+    let response: URLResponse
+    do {
+      (responseBody, response) = try await data(for: request)
+    }
+    catch {
+      if let replayError = request.streamingBodyRequestProperty?.recordedReplayError {
+        throw replayError
+      }
+      throw error
+    }
 
     return try validate(responseBody: responseBody, response: response)
   }
@@ -286,7 +296,14 @@ private final class SundayURLSessionDelegate: NSObject, URLSessionTaskDelegate {
       return
     }
 
-    completionHandler(try? property.body.makeInputStream())
+    do {
+      completionHandler(try property.body.makeInputStream())
+    }
+    catch {
+      property.recordReplayError(error)
+      task.cancel()
+      completionHandler(nil)
+    }
   }
 
   public func urlSession(
@@ -310,6 +327,18 @@ private final class SundayURLSessionDelegate: NSObject, URLSessionTaskDelegate {
     }
 
     completionHandler(.cancelAuthenticationChallenge, nil)
+  }
+
+}
+
+
+private extension URLRequest {
+
+  var streamingBodyRequestProperty: StreamingBodyRequestProperty? {
+    URLProtocol.property(
+      forKey: streamingBodyRequestPropertyKey,
+      in: self
+    ) as? StreamingBodyRequestProperty
   }
 
 }

--- a/Sources/Sunday/URLSessionTransport+Convenience.swift
+++ b/Sources/Sunday/URLSessionTransport+Convenience.swift
@@ -18,7 +18,7 @@
 public extension URLSessionTransport {
 
   /// Executes a request with a literal path and validates a void result.
-  func result<B: Encodable>(
+  func result<B: Encodable & Sendable>(
     method: HTTP.Method,
     path: String,
     body: B? = nil,
@@ -38,7 +38,7 @@ public extension URLSessionTransport {
   }
 
   /// Executes a request with a literal path and decodes a typed result.
-  func result<B: Encodable, D: Decodable>(
+  func result<B: Encodable & Sendable, D: Decodable>(
     method: HTTP.Method,
     path: String,
     body: B? = nil,

--- a/Sources/Sunday/URLSessionTransport.swift
+++ b/Sources/Sunday/URLSessionTransport.swift
@@ -62,7 +62,9 @@ public final class URLSessionTransport: Transport, Sendable {
   ///
   /// - Parameters:
   ///   - baseURL: Base URI template used to resolve request paths.
-  ///   - session: Session used for non-streaming requests and responses.
+  ///   - session: Session used for non-streaming requests and responses. Use `URLSession.sunday(...)`,
+  ///     or an equivalent delegate implementation, when streaming uploads must be replayed for
+  ///     redirects or authentication retries.
   ///   - eventSession: Session used for server-sent event streams. Pass `session` when event streams
   ///     must use the same delegate or session behavior. Pass a session created with
   ///     `.sunday(configuration: .events(...))` or an equivalent configuration when SSE-specific

--- a/Sources/Sunday/URLSessionTransport.swift
+++ b/Sources/Sunday/URLSessionTransport.swift
@@ -40,7 +40,7 @@ private struct URLSessionTransportState: Sendable {
 }
 
 
-// swiftlint:disable type_body_length function_parameter_count
+// swiftlint:disable type_body_length
 /// URLSession-backed transport shared by generated clients.
 public final class URLSessionTransport: Transport, Sendable {
 
@@ -143,47 +143,12 @@ public final class URLSessionTransport: Transport, Sendable {
         encoders: pathEncoders
       )
 
-    // Encode & add query parameters to url
-    if let queryParameters = spec.queryParameters, !queryParameters.isEmpty {
+    url = try appendQueryParameters(spec.queryParameters, to: url)
 
-      guard let urlQueryEncoder = try mediaTypeEncoders.find(for: .wwwFormUrlEncoded) as? WWWFormURLEncoder else {
-        fatalError("MediaTypeEncoder for \(MediaType.wwwFormUrlEncoded) must be an instance of WWWFormURLEncoder")
-      }
-
-      var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)!
-      urlComponents.percentEncodedQuery = try urlQueryEncoder.encodeQueryString(parameters: queryParameters)
-
-      guard let queryUrl = urlComponents.url else {
-        throw SundayError.invalidURL(urlComponents)
-      }
-
-      url = queryUrl
-    }
-
-    // Build basic request
     var urlRequest = URLRequest(url: url)
     urlRequest.httpMethod = spec.method.rawValue
-
-    // Encode and add headers
-    if let headers = spec.headers {
-
-      try HeaderParameters.encode(headers: headers)
-        .forEach { entry in
-          urlRequest.addValue(entry.value, forHTTPHeaderField: entry.name)
-        }
-    }
-
-    // Determine & add accept header
-    if let acceptTypes = spec.acceptTypes {
-      let supportedAcceptTypes = acceptTypes.filter { mediaTypeDecoders.supports(for: $0) }
-      if supportedAcceptTypes.isEmpty {
-        throw SundayError.requestEncodingFailed(reason: .noSupportedAcceptTypes(acceptTypes))
-      }
-
-      let accept = supportedAcceptTypes.map(\.value).joined(separator: " , ")
-
-      urlRequest.setValue(accept, forHTTPHeaderField: HTTP.StdHeaders.accept)
-    }
+    try appendHeaders(spec.headers, to: &urlRequest)
+    try appendAcceptHeader(spec.acceptTypes, to: &urlRequest)
 
     let preparedBody = try spec.prepareBody(mediaTypeEncoders: mediaTypeEncoders)
     let contentType =
@@ -198,23 +163,88 @@ public final class URLSessionTransport: Transport, Sendable {
     switch preparedBody {
     case .data(let data, _):
       urlRequest.httpBody = data
-    case .stream(let streamingBody, _):
-      urlRequest.httpBodyStream = try streamingBody.makeInputStream()
-      let mutableRequest = (urlRequest as NSURLRequest).mutableCopy() as? NSMutableURLRequest
-      guard let mutableRequest else {
-        throw SundayError.requestEncodingFailed(reason: .streamCreationFailed)
-      }
-      URLProtocol.setProperty(
-        StreamingBodyRequestProperty(body: streamingBody),
-        forKey: streamingBodyRequestPropertyKey,
-        in: mutableRequest
-      )
-      urlRequest = mutableRequest as URLRequest
+    case .stream:
+      break
     case nil:
       break
     }
 
-    return try await adapter?.adapt(transport: self, urlRequest: urlRequest) ?? urlRequest
+    urlRequest = try await adapter?.adapt(transport: self, urlRequest: urlRequest) ?? urlRequest
+
+    switch preparedBody {
+    case .stream(let streamingBody, _):
+      urlRequest = try attachStreamingBody(streamingBody, to: urlRequest)
+    case .data, nil:
+      break
+    }
+
+    return urlRequest
+  }
+
+  private func appendQueryParameters(_ queryParameters: Parameters?, to url: URL) throws -> URL {
+
+    guard let queryParameters = queryParameters, !queryParameters.isEmpty else {
+      return url
+    }
+
+    guard let urlQueryEncoder = try mediaTypeEncoders.find(for: .wwwFormUrlEncoded) as? WWWFormURLEncoder else {
+      fatalError("MediaTypeEncoder for \(MediaType.wwwFormUrlEncoded) must be an instance of WWWFormURLEncoder")
+    }
+
+    var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)!
+    urlComponents.percentEncodedQuery = try urlQueryEncoder.encodeQueryString(parameters: queryParameters)
+
+    guard let queryUrl = urlComponents.url else {
+      throw SundayError.invalidURL(urlComponents)
+    }
+
+    return queryUrl
+  }
+
+  private func appendHeaders(_ headers: Parameters?, to urlRequest: inout URLRequest) throws {
+
+    guard let headers else {
+      return
+    }
+
+    try HeaderParameters.encode(headers: headers)
+      .forEach { entry in
+        urlRequest.addValue(entry.value, forHTTPHeaderField: entry.name)
+      }
+  }
+
+  private func appendAcceptHeader(_ acceptTypes: [MediaType]?, to urlRequest: inout URLRequest) throws {
+
+    guard let acceptTypes else {
+      return
+    }
+
+    let supportedAcceptTypes = acceptTypes.filter { mediaTypeDecoders.supports(for: $0) }
+    if supportedAcceptTypes.isEmpty {
+      throw SundayError.requestEncodingFailed(reason: .noSupportedAcceptTypes(acceptTypes))
+    }
+
+    let accept = supportedAcceptTypes.map(\.value).joined(separator: " , ")
+
+    urlRequest.setValue(accept, forHTTPHeaderField: HTTP.StdHeaders.accept)
+  }
+
+  private func attachStreamingBody(_ streamingBody: StreamingBody, to request: URLRequest) throws -> URLRequest {
+
+    var request = request
+    request.httpBodyStream = try streamingBody.makeInputStream()
+
+    let mutableRequest = (request as NSURLRequest).mutableCopy() as? NSMutableURLRequest
+    guard let mutableRequest else {
+      throw SundayError.requestEncodingFailed(reason: .streamCreationFailed)
+    }
+    URLProtocol.setProperty(
+      StreamingBodyRequestProperty(body: streamingBody),
+      forKey: streamingBodyRequestPropertyKey,
+      in: mutableRequest
+    )
+
+    return mutableRequest as URLRequest
   }
 
   private func dataResponse(request: URLRequest) async throws -> (Data?, HTTPURLResponse) {
@@ -564,4 +594,4 @@ public final class URLSessionTransport: Transport, Sendable {
   }
 
 }
-// swiftlint:enable type_body_length function_parameter_count
+// swiftlint:enable type_body_length

--- a/Sources/Sunday/URLSessionTransport.swift
+++ b/Sources/Sunday/URLSessionTransport.swift
@@ -130,20 +130,19 @@ public final class URLSessionTransport: Transport, Sendable {
     problemTypes.withLock { $0[type] = RegisteredProblem.erase(problemType) }
   }
 
-  public func transportRequest<B: Encodable>(
-    method: HTTP.Method, pathTemplate: String, pathParameters: Parameters? = nil, queryParameters: Parameters? = nil,
-    body: B?, contentTypes: [MediaType]? = nil, acceptTypes: [MediaType]? = nil, headers: Parameters? = nil
+  public func transportRequest<RequestBody: Sendable>(
+    spec: OperationSpec<RequestBody>
   ) async throws -> URLRequest {
 
     var url =
       try baseURL.complete(
-        relative: pathTemplate,
-        parameters: try URI.Template.parameters(from: pathParameters ?? [:]),
+        relative: spec.pathTemplate,
+        parameters: try URI.Template.parameters(from: spec.pathParameters ?? [:]),
         encoders: pathEncoders
       )
 
     // Encode & add query parameters to url
-    if let queryParameters = queryParameters, !queryParameters.isEmpty {
+    if let queryParameters = spec.queryParameters, !queryParameters.isEmpty {
 
       guard let urlQueryEncoder = try mediaTypeEncoders.find(for: .wwwFormUrlEncoded) as? WWWFormURLEncoder else {
         fatalError("MediaTypeEncoder for \(MediaType.wwwFormUrlEncoded) must be an instance of WWWFormURLEncoder")
@@ -161,10 +160,10 @@ public final class URLSessionTransport: Transport, Sendable {
 
     // Build basic request
     var urlRequest = URLRequest(url: url)
-    urlRequest.httpMethod = method.rawValue
+    urlRequest.httpMethod = spec.method.rawValue
 
     // Encode and add headers
-    if let headers = headers {
+    if let headers = spec.headers {
 
       try HeaderParameters.encode(headers: headers)
         .forEach { entry in
@@ -173,7 +172,7 @@ public final class URLSessionTransport: Transport, Sendable {
     }
 
     // Determine & add accept header
-    if let acceptTypes = acceptTypes {
+    if let acceptTypes = spec.acceptTypes {
       let supportedAcceptTypes = acceptTypes.filter { mediaTypeDecoders.supports(for: $0) }
       if supportedAcceptTypes.isEmpty {
         throw SundayError.requestEncodingFailed(reason: .noSupportedAcceptTypes(acceptTypes))
@@ -184,20 +183,33 @@ public final class URLSessionTransport: Transport, Sendable {
       urlRequest.setValue(accept, forHTTPHeaderField: HTTP.StdHeaders.accept)
     }
 
-    // Determine content type
-    let contentType = contentTypes?.first { mediaTypeEncoders.supports(for: $0) }
+    let preparedBody = try spec.prepareBody(mediaTypeEncoders: mediaTypeEncoders)
+    let contentType =
+      preparedBody?.contentType ??
+      spec.contentTypes?.first { mediaTypeEncoders.supports(for: $0) }
 
     // If matched, add content type (even if body is nil, to match any expected server requirements)
     if let contentType = contentType {
       urlRequest.setValue(contentType.value, forHTTPHeaderField: HTTP.StdHeaders.contentType)
     }
 
-    // Encode & add body data
-    if let body = body {
-      guard let contentType = contentType else {
-        throw SundayError.requestEncodingFailed(reason: .noSupportedContentTypes(contentTypes ?? []))
+    switch preparedBody {
+    case .data(let data, _):
+      urlRequest.httpBody = data
+    case .stream(let streamingBody, _):
+      urlRequest.httpBodyStream = try streamingBody.makeInputStream()
+      let mutableRequest = (urlRequest as NSURLRequest).mutableCopy() as? NSMutableURLRequest
+      guard let mutableRequest else {
+        throw SundayError.requestEncodingFailed(reason: .streamCreationFailed)
       }
-      urlRequest.httpBody = try mediaTypeEncoders.find(for: contentType).encode(body)
+      URLProtocol.setProperty(
+        StreamingBodyRequestProperty(body: streamingBody),
+        forKey: streamingBodyRequestPropertyKey,
+        in: mutableRequest
+      )
+      urlRequest = mutableRequest as URLRequest
+    case nil:
+      break
     }
 
     return try await adapter?.adapt(transport: self, urlRequest: urlRequest) ?? urlRequest
@@ -208,22 +220,11 @@ public final class URLSessionTransport: Transport, Sendable {
     return try await session.validatedData(for: request)
   }
 
-  private func dataResponse<B: Encodable>(
-    method: HTTP.Method, pathTemplate: String, pathParameters: Parameters? = nil, queryParameters: Parameters? = nil,
-    body: B?, contentTypes: [MediaType]? = nil, acceptTypes: [MediaType]? = nil, headers: Parameters? = nil
+  private func dataResponse<RequestBody: Sendable>(
+    spec: OperationSpec<RequestBody>
   ) async throws -> (Data?, HTTPURLResponse) {
 
-    let request = try await transportRequest(
-      method: method,
-      pathTemplate: pathTemplate,
-      pathParameters: pathParameters,
-      queryParameters: queryParameters,
-      body: body,
-      contentTypes: contentTypes,
-      acceptTypes: acceptTypes,
-      headers: headers
-    )
-
+    let request = try await transportRequest(spec: spec)
     return try await dataResponse(request: request)
   }
 
@@ -231,23 +232,10 @@ public final class URLSessionTransport: Transport, Sendable {
     try await dataResponse(request: request).1
   }
 
-  public func transportResponse<B: Encodable>(
-    method: HTTP.Method, pathTemplate: String, pathParameters: Parameters? = nil, queryParameters: Parameters? = nil,
-    body: B?, contentTypes: [MediaType]? = nil, acceptTypes: [MediaType]? = nil, headers: Parameters? = nil
+  public func transportResponse<RequestBody: Sendable>(
+    spec: OperationSpec<RequestBody>
   ) async throws -> HTTPURLResponse {
-
-    let request = try await transportRequest(
-      method: method,
-      pathTemplate: pathTemplate,
-      pathParameters: pathParameters,
-      queryParameters: queryParameters,
-      body: body,
-      contentTypes: contentTypes,
-      acceptTypes: acceptTypes,
-      headers: headers
-    )
-
-    return try await transportResponse(request: request)
+    try await dataResponse(spec: spec).1
   }
 
   public func parse<D: Decodable>(dataResponse: (Data?, HTTPURLResponse)) throws -> D {
@@ -348,29 +336,13 @@ public final class URLSessionTransport: Transport, Sendable {
     }
   }
 
-  public func response<B: Encodable, D: Decodable>(
-    method: HTTP.Method,
-    pathTemplate: String,
-    pathParameters: Parameters?,
-    queryParameters: Parameters?,
-    body: B?,
-    contentTypes: [MediaType]?,
-    acceptTypes: [MediaType]?,
-    headers: Parameters?
+  public func response<RequestBody: Sendable, D: Decodable>(
+    spec: OperationSpec<RequestBody>
   ) async throws -> OperationResponse<D> {
 
     do {
 
-      let dataResponse = try await dataResponse(
-        method: method,
-        pathTemplate: pathTemplate,
-        pathParameters: pathParameters,
-        queryParameters: queryParameters,
-        body: body,
-        contentTypes: contentTypes,
-        acceptTypes: acceptTypes,
-        headers: headers
-      )
+      let dataResponse = try await dataResponse(spec: spec)
 
       let result = try parse(dataResponse: dataResponse) as D
 
@@ -382,29 +354,13 @@ public final class URLSessionTransport: Transport, Sendable {
 
   }
 
-  public func response<B>(
-    method: HTTP.Method,
-    pathTemplate: String,
-    pathParameters: Parameters?,
-    queryParameters: Parameters?,
-    body: B?,
-    contentTypes: [MediaType]?,
-    acceptTypes: [MediaType]?,
-    headers: Parameters?
-  ) async throws -> OperationResponse<Void> where B: Encodable {
+  public func response<RequestBody: Sendable>(
+    spec: OperationSpec<RequestBody>
+  ) async throws -> OperationResponse<Void> {
 
     do {
 
-      let dataResponse = try await dataResponse(
-        method: method,
-        pathTemplate: pathTemplate,
-        pathParameters: pathParameters,
-        queryParameters: queryParameters,
-        body: body,
-        contentTypes: contentTypes,
-        acceptTypes: acceptTypes,
-        headers: headers
-      )
+      let dataResponse = try await dataResponse(spec: spec)
 
       _ = try parse(dataResponse: dataResponse) as Empty
 
@@ -416,23 +372,13 @@ public final class URLSessionTransport: Transport, Sendable {
 
   }
 
-  public func result<B: Encodable, D: Decodable>(
-    method: HTTP.Method, pathTemplate: String, pathParameters: Parameters? = nil, queryParameters: Parameters? = nil,
-    body: B?, contentTypes: [MediaType]? = nil, acceptTypes: [MediaType]? = nil, headers: Parameters? = nil
+  public func result<RequestBody: Sendable, D: Decodable>(
+    spec: OperationSpec<RequestBody>
   ) async throws -> D {
 
     do {
 
-      let dataResponse = try await dataResponse(
-        method: method,
-        pathTemplate: pathTemplate,
-        pathParameters: pathParameters,
-        queryParameters: queryParameters,
-        body: body,
-        contentTypes: contentTypes,
-        acceptTypes: acceptTypes,
-        headers: headers
-      )
+      let dataResponse = try await dataResponse(spec: spec)
 
       return try parse(dataResponse: dataResponse)
 
@@ -470,23 +416,13 @@ public final class URLSessionTransport: Transport, Sendable {
     }
   }
 
-  public func result<B: Encodable>(
-    method: HTTP.Method, pathTemplate: String, pathParameters: Parameters?, queryParameters: Parameters?,
-    body: B?, contentTypes: [MediaType]?, acceptTypes: [MediaType]?, headers: Parameters?
+  public func result<RequestBody: Sendable>(
+    spec: OperationSpec<RequestBody>
   ) async throws {
 
     do {
 
-      let dataResponse = try await dataResponse(
-        method: method,
-        pathTemplate: pathTemplate,
-        pathParameters: pathParameters,
-        queryParameters: queryParameters,
-        body: body,
-        contentTypes: contentTypes,
-        acceptTypes: acceptTypes,
-        headers: headers
-      )
+      let dataResponse = try await dataResponse(spec: spec)
 
       _ = try parse(dataResponse: dataResponse) as Empty
 
@@ -499,24 +435,12 @@ public final class URLSessionTransport: Transport, Sendable {
   /// Creates a caller-owned event source for the generated request.
   ///
   /// The returned source is not retained by the transport. Callers are responsible for closing it.
-  public func eventSource<B>(
-    method: HTTP.Method, pathTemplate: String, pathParameters: Parameters? = nil, queryParameters: Parameters? = nil,
-    body: B?, contentTypes: [MediaType]? = nil, acceptTypes: [MediaType]? = nil, headers: Parameters? = nil
-  ) -> EventSource where B: Encodable & Sendable {
+  public func eventSource<RequestBody: Sendable>(spec: OperationSpec<RequestBody>) -> EventSource {
 
     eventSource(from: { @Sendable [weak self] in
       guard let self else { return nil }
 
-      return try await self.transportRequest(
-        method: method,
-        pathTemplate: pathTemplate,
-        pathParameters: pathParameters,
-        queryParameters: queryParameters,
-        body: body,
-        contentTypes: contentTypes,
-        acceptTypes: acceptTypes,
-        headers: headers
-      )
+      return try await self.transportRequest(spec: spec)
     })
   }
 
@@ -539,27 +463,17 @@ public final class URLSessionTransport: Transport, Sendable {
     }
   }
 
-  public func eventStream<B, D>(
-    method: HTTP.Method, pathTemplate: String, pathParameters: Parameters? = nil, queryParameters: Parameters? = nil,
-    body: B?, contentTypes: [MediaType]? = nil, acceptTypes: [MediaType]? = nil, headers: Parameters? = nil,
+  public func eventStream<RequestBody: Sendable, D>(
+    spec: OperationSpec<RequestBody>,
     decoder: @escaping @Sendable (TextMediaTypeDecoder, String?, String?, String, Logger) throws -> D?
-  ) -> AsyncStream<D> where B: Encodable & Sendable {
+  ) -> AsyncStream<D> {
 
     eventStream(
       decoder: decoder,
       from: { @Sendable [weak self] in
         guard let self else { return nil }
 
-        return try await self.transportRequest(
-          method: method,
-          pathTemplate: pathTemplate,
-          pathParameters: pathParameters,
-          queryParameters: queryParameters,
-          body: body,
-          contentTypes: contentTypes,
-          acceptTypes: acceptTypes,
-          headers: headers
-        )
+        return try await self.transportRequest(spec: spec)
       }
     )
   }

--- a/Sources/SundayServer/HTTPHeaderParser.swift
+++ b/Sources/SundayServer/HTTPHeaderParser.swift
@@ -217,7 +217,7 @@ public struct HTTPRequestParser {
           }
 
           // ensure entire encoded chunk is available
-          if (lengthLineEnd + length + Self.newlineData.count) > data.count {
+          if (lengthLineEnd + length + Self.newlineData.count) > buffer.count {
             return nil
           }
 
@@ -237,8 +237,7 @@ public struct HTTPRequestParser {
             // add content length
             pushHeader(name: HTTP.StdHeaders.contentLength, value: Data(String(entity?.count ?? 0).utf8))
 
-            // parse trailing headers (if any)
-            state = .headers
+            return try finish()
 
           }
           else {

--- a/Sources/SundayServer/HTTPHeaderParser.swift
+++ b/Sources/SundayServer/HTTPHeaderParser.swift
@@ -53,6 +53,7 @@ public struct HTTPRequestParser {
     case line
     case headers
     case body
+    case trailers
   }
 
   private static let newlineData = Data([0xD, 0xA])
@@ -71,7 +72,7 @@ public struct HTTPRequestParser {
   ///  - Returns: parsed headers elements
   mutating func process( // swiftlint:disable:this cyclomatic_complexity function_body_length
     _ data: Data,
-    connection: HTTPConnection
+    connection: HTTPConnection? = nil
   ) throws -> ParsedRequest? {
 
     func finish() throws -> ParsedRequest? {
@@ -118,6 +119,17 @@ public struct HTTPRequestParser {
       headers?.append((name: name, value: value))
     }
 
+    func parseHeader(_ lineBytes: Data) throws {
+      let parts: [Data] = lineBytes.split(separator: Self.headerSeparator, maxSplits: 1)
+      guard parts.count == 2, let name = String(data: parts[0], encoding: .ascii)?.lowercased() else {
+        throw Error.invalidHeaderData
+      }
+
+      let value = Data(parts[1].drop { $0 == Character(" ").asciiValue })
+
+      pushHeader(name: name, value: value)
+    }
+
     // Add to "current" data, will include data that couldn't be processed
     // in previous calls
     buffer.append(data)
@@ -160,7 +172,7 @@ public struct HTTPRequestParser {
             $0.name.lowercased() == HTTP.StdHeaders.expect && $0.value == Data("100-continue".utf8)
           }) {
 
-            connection.send(
+            connection?.send(
               data: Data("HTTP/1.1 \(HTTP.Response.Status.continue)\r\n\r\n".utf8),
               context: "Sending continuation for expectation"
             )
@@ -173,15 +185,7 @@ public struct HTTPRequestParser {
         }
         else {
 
-          // parse raw header
-          let parts: [Data] = lineBytes.split(separator: Self.headerSeparator, maxSplits: 1)
-          guard parts.count == 2, let name = String(data: parts[0], encoding: .ascii)?.lowercased() else {
-            throw Error.invalidHeaderData
-          }
-
-          let value = Data(parts[1].drop { $0 == Character(" ").asciiValue })
-
-          pushHeader(name: name, value: value)
+          try parseHeader(lineBytes)
         }
 
       case .body:
@@ -224,6 +228,16 @@ public struct HTTPRequestParser {
           // remove length line from data buffer
           buffer = Data(buffer.suffix(from: lengthLineEnd))
 
+          if length == 0 {
+            // all chunks are here
+
+            // add content length
+            pushHeader(name: HTTP.StdHeaders.contentLength, value: Data(String(entity?.count ?? 0).utf8))
+
+            state = .trailers
+            continue
+          }
+
           let chunkData = popBytes(count: length)
 
           // chunks are terminated with a newline, it should be left in the buffer... pop it and verify
@@ -231,27 +245,27 @@ public struct HTTPRequestParser {
             throw Error.invalidChunkFormat
           }
 
-          if chunkData.count == 0 {
-            // all chunks are here
-
-            // add content length
-            pushHeader(name: HTTP.StdHeaders.contentLength, value: Data(String(entity?.count ?? 0).utf8))
-
-            return try finish()
-
+          // save chunk data and wait for next
+          if entity == nil {
+            entity = chunkData
           }
           else {
-
-            // save chunk data and wait for next
-            if entity == nil {
-              entity = chunkData
-            }
-            else {
-              entity!.append(chunkData)
-            }
+            entity!.append(chunkData)
           }
 
         }
+
+      case .trailers:
+        guard let lineBytes = popLineBytes() else {
+          // no newline so return and wait for more trailer data
+          return nil
+        }
+
+        guard !lineBytes.isEmpty else {
+          return try finish()
+        }
+
+        try parseHeader(lineBytes)
 
       }
     }

--- a/Sources/SundayServer/RoutingHTTPServer.swift
+++ b/Sources/SundayServer/RoutingHTTPServer.swift
@@ -113,6 +113,10 @@ public final class RoutingHTTPServer: NSObject, HTTPServer, Sendable {
   @available(watchOS, unavailable)
   public func start(timeout: TimeInterval = 30) -> URL? {
 
+    guard canStartListener() else {
+      return nil
+    }
+
     let deadline = DispatchTime.now() + timeout
     let starter = DispatchGroup()
 
@@ -153,6 +157,10 @@ public final class RoutingHTTPServer: NSObject, HTTPServer, Sendable {
 
   public func startLocal(timeout: TimeInterval = 30) -> URL? {
 
+    guard canStartListener() else {
+      return nil
+    }
+
     listener.start(queue: queue)
 
     guard waitForReady(deadline: DispatchTime.now() + timeout) else {
@@ -167,10 +175,25 @@ public final class RoutingHTTPServer: NSObject, HTTPServer, Sendable {
   }
 
   public func stop() {
+    if recordTerminalState(.cancelled) {
+      readyGroup.leave()
+    }
+
     listener.cancel()
     connections.withLock { connections in
       connections.values.forEach { $0.close() }
       connections.removeAll()
+    }
+  }
+
+  private func canStartListener() -> Bool {
+    return stateStorage.withLock { storedState in
+      switch storedState.listenerState {
+      case .cancelled?, .failed?:
+        return false
+      default:
+        return true
+      }
     }
   }
 
@@ -179,7 +202,13 @@ public final class RoutingHTTPServer: NSObject, HTTPServer, Sendable {
   }
 
   private func update(state: NWListener.State) {
-    let shouldSignalReady = stateStorage.withLock { storedState in
+    if recordTerminalState(state) {
+      readyGroup.leave()
+    }
+  }
+
+  private func recordTerminalState(_ state: NWListener.State) -> Bool {
+    return stateStorage.withLock { storedState in
       storedState.listenerState = state
       storedState.isReady = state == .ready
       let isTerminal =
@@ -192,10 +221,6 @@ public final class RoutingHTTPServer: NSObject, HTTPServer, Sendable {
       }
       storedState.readySignaled = true
       return true
-    }
-
-    if shouldSignalReady {
-      readyGroup.leave()
     }
   }
 

--- a/Tests/SundayTests/ServerTests.swift
+++ b/Tests/SundayTests/ServerTests.swift
@@ -223,6 +223,30 @@ class HTTPServerTests: XCTestCase {
     XCTAssertEqual(data, Data("12345678901234567890".utf8))
   }
 
+  func testChunkedRequestTrailersAreParsed() throws {
+
+    let request =
+      "POST /trailers HTTP/1.1\r\n" +
+      "Host: localhost\r\n" +
+      "Transfer-Encoding: chunked\r\n" +
+      "Trailer: X-Upload-Digest\r\n" +
+      "\r\n" +
+      "5\r\n" +
+      "hello\r\n" +
+      "0\r\n" +
+      "X-Upload-Digest: sha-256=12345\r\n" +
+      "\r\n"
+
+    var parser = HTTPRequestParser()
+    let parsedRequest = try XCTUnwrap(parser.process(Data(request.utf8)))
+
+    XCTAssertEqual(parsedRequest.body, Data("hello".utf8))
+    XCTAssertEqual(
+      parsedRequest.headers.first { $0.name == "x-upload-digest" }.flatMap { String(data: $0.value, encoding: .ascii) },
+      "sha-256=12345"
+    )
+  }
+
   func testStartLocalAfterStopReturnsBeforeTimeout() throws {
 
     let server = try RoutingHTTPServer(port: .any, localOnly: true)

--- a/Tests/SundayTests/URLSessionTransportTests.swift
+++ b/Tests/SundayTests/URLSessionTransportTests.swift
@@ -441,6 +441,65 @@ class URLSessionTransportTests: XCTestCase {
     XCTAssertEqual(requestCount.withLock { $0 }, 2)
   }
 
+  func testStreamingBodyReplaySurfacesStreamCreationError() async throws {
+
+    let body = Data("redirected-stream".utf8)
+    let contentType = try MediaType(valid: "application/x-tar")
+    let server = try RoutingHTTPServer(port: .any, localOnly: true) {
+      Path("/redirect") {
+        POST { _, res in
+          res.send(
+            status: .temporaryRedirect,
+            headers: [HTTP.StdHeaders.location: ["/api"]],
+            body: Data()
+          )
+        }
+      }
+      Path("/api") {
+        POST { _, res in
+          res.send(statusCode: .noContent)
+        }
+      }
+    }
+
+    guard let serverURL = server.startLocal(timeout: 5.0) else {
+      XCTFail("could not start local server")
+      return
+    }
+    defer { server.stop() }
+
+    let factoryCount = Mutex(0)
+    let transport = URLSessionTransport(baseURL: .init(format: serverURL.absoluteString))
+    let operation: StreamingOperation<Void, URLSessionTransport> =
+      Operation(
+        transport: transport,
+        spec: .streaming(
+          method: .post,
+          pathTemplate: "/redirect",
+          body: StreamingBody(stream: {
+            let count = factoryCount.withLock {
+              $0 += 1
+              return $0
+            }
+            guard count == 1 else {
+              throw StreamingBodyTestError.replayFailed
+            }
+            return InputStream(data: body)
+          }),
+          contentTypes: [contentType]
+        )
+      )
+
+    try await XCTAssertThrowsError(try await operation.execute()) { error in
+      guard case StreamingBodyTestError.replayFailed = error else {
+        XCTFail("Incorrect Error: \(error)")
+        return
+      }
+    }
+
+    XCTAssertGreaterThanOrEqual(factoryCount.withLock { $0 }, 2)
+  }
+
   func testStreamingAsyncBytesBodyStartsWhenStreamOpens() async throws {
 
     let state = TrackingByteSequence.State()
@@ -1557,6 +1616,11 @@ class URLSessionTransportTests: XCTestCase {
     XCTAssertNil(result)
   }
 
+}
+
+
+private enum StreamingBodyTestError: Error {
+  case replayFailed
 }
 
 

--- a/Tests/SundayTests/URLSessionTransportTests.swift
+++ b/Tests/SundayTests/URLSessionTransportTests.swift
@@ -383,6 +383,62 @@ class URLSessionTransportTests: XCTestCase {
     XCTAssertEqual(requestCount.withLock { $0 }, 2)
   }
 
+  func testExecutesConcurrentStreamingAsyncBytesBodies() async throws {
+
+    let contentType = try MediaType(valid: "application/x-tar")
+    let receivedBodies = Mutex<[String]>([])
+    let server = try RoutingHTTPServer(port: .any, localOnly: true) {
+      Path("/api") {
+        POST { req, res in
+          if let data = req.body, let body = String(data: data, encoding: .utf8) {
+            receivedBodies.withLock { $0.append(body) }
+          }
+          XCTAssertEqual(req.header(for: HTTP.StdHeaders.transferEncoding), "chunked")
+          res.send(statusCode: .noContent)
+        }
+      }
+    }
+
+    guard let serverURL = server.startLocal(timeout: 5.0) else {
+      XCTFail("could not start local server")
+      return
+    }
+    defer { server.stop() }
+
+    let transport = URLSessionTransport(baseURL: .init(format: serverURL.absoluteString))
+
+    try await withThrowingTaskGroup(of: Void.self) { group in
+      for index in 0 ..< 8 {
+        group.addTask {
+          let operation: StreamingOperation<Void, URLSessionTransport> =
+            Operation(
+              transport: transport,
+              spec: .streaming(
+                method: .post,
+                pathTemplate: "/api",
+                body: StreamingBody.bytes {
+                  AsyncStream { continuation in
+                    continuation.yield(Data("body-\(index)".utf8))
+                    continuation.finish()
+                  }
+                },
+                contentTypes: [contentType]
+              )
+            )
+
+          try await operation.execute()
+        }
+      }
+
+      try await group.waitForAll()
+    }
+
+    XCTAssertEqual(
+      receivedBodies.withLock { $0.sorted() },
+      (0 ..< 8).map { "body-\($0)" }
+    )
+  }
+
   func testStreamingAsyncBytesBodyCanBeReplayedForTemporaryRedirect() async throws {
 
     let chunks = [Data("redirected-".utf8), Data("stream".utf8)]

--- a/Tests/SundayTests/URLSessionTransportTests.swift
+++ b/Tests/SundayTests/URLSessionTransportTests.swift
@@ -441,6 +441,8 @@ class URLSessionTransportTests: XCTestCase {
 
   func testStreamingAsyncBytesBodyCanBeReplayedForTemporaryRedirect() async throws {
 
+    try skipIfStreamingBodyReplayIsUnsupported()
+
     let chunks = [Data("redirected-".utf8), Data("stream".utf8)]
     let body = chunks.reduce(into: Data()) { $0.append($1) }
     let contentType = try MediaType(valid: "application/x-tar")
@@ -499,6 +501,8 @@ class URLSessionTransportTests: XCTestCase {
 
   func testStreamingBodyReplaySurfacesStreamCreationError() async throws {
 
+    try skipIfStreamingBodyReplayIsUnsupported()
+
     let body = Data("redirected-stream".utf8)
     let contentType = try MediaType(valid: "application/x-tar")
     let server = try RoutingHTTPServer(port: .any, localOnly: true) {
@@ -554,6 +558,13 @@ class URLSessionTransportTests: XCTestCase {
     }
 
     XCTAssertGreaterThanOrEqual(factoryCount.withLock { $0 }, 2)
+  }
+
+  private func skipIfStreamingBodyReplayIsUnsupported() throws {
+
+    #if os(watchOS)
+    throw XCTSkip("URLSession does not request a replacement body stream for redirected streaming uploads on watchOS.")
+    #endif
   }
 
   func testStreamingAsyncBytesBodyStartsWhenStreamOpens() async throws {

--- a/Tests/SundayTests/URLSessionTransportTests.swift
+++ b/Tests/SundayTests/URLSessionTransportTests.swift
@@ -222,6 +222,230 @@ class URLSessionTransportTests: XCTestCase {
     XCTAssertEqual(request.value(forHTTPHeaderField: HTTP.StdHeaders.contentType), "application/json")
   }
 
+  func testAttachesStreamingFileBody() async throws {
+
+    let body = Data("archive-data".utf8)
+    let bodyURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString)
+      .appendingPathExtension("tar")
+    try body.write(to: bodyURL)
+    defer { try? FileManager.default.removeItem(at: bodyURL) }
+
+    let contentType = try MediaType(valid: "application/x-tar")
+    let transport = URLSessionTransport(baseURL: "http://example.com")
+
+    let request =
+      try await transport.transportRequest(
+        spec: OperationSpec.streaming(
+          method: .post,
+          pathTemplate: "/api",
+          body: .file(bodyURL),
+          contentTypes: [contentType]
+        )
+      )
+
+    XCTAssertNil(request.httpBody)
+    XCTAssertEqual(request.value(forHTTPHeaderField: HTTP.StdHeaders.contentType), "application/x-tar")
+
+    let stream = try XCTUnwrap(request.httpBodyStream)
+    stream.open()
+    defer { stream.close() }
+
+    var buffer = [UInt8](repeating: 0, count: 16)
+    let count = stream.read(&buffer, maxLength: buffer.count)
+    XCTAssertEqual(Data(buffer.prefix(count)), body)
+  }
+
+  func testExecutesStreamingOperationWithStreamBody() async throws {
+
+    let body = Data("streamed-request-body".utf8)
+    let contentType = try MediaType(valid: "application/x-tar")
+    let server = try RoutingHTTPServer(port: .any, localOnly: true) {
+      Path("/api") {
+        POST { req, res in
+          XCTAssertEqual(req.body, body)
+          XCTAssertEqual(req.header(for: HTTP.StdHeaders.contentType), contentType.value)
+          XCTAssertEqual(req.header(for: HTTP.StdHeaders.transferEncoding), "chunked")
+          res.send(statusCode: .noContent)
+        }
+      }
+    }
+
+    guard let serverURL = server.startLocal(timeout: 5.0) else {
+      XCTFail("could not start local server")
+      return
+    }
+    defer { server.stop() }
+
+    let transport = URLSessionTransport(baseURL: .init(format: serverURL.absoluteString))
+    let operation: StreamingOperation<Void, URLSessionTransport> =
+      Operation(
+        transport: transport,
+        spec: .streaming(
+          method: .post,
+          pathTemplate: "/api",
+          body: StreamingBody(stream: { InputStream(data: body) }),
+          contentTypes: [contentType]
+        )
+      )
+
+    try await operation.execute()
+  }
+
+  func testExecutesStreamingOperationWithAsyncBytesBody() async throws {
+
+    let chunks = [Data("streamed-".utf8), Data("async-".utf8), Data("body".utf8)]
+    let body = chunks.reduce(into: Data()) { $0.append($1) }
+    let contentType = try MediaType(valid: "application/x-tar")
+    let server = try RoutingHTTPServer(port: .any, localOnly: true) {
+      Path("/api") {
+        POST { req, res in
+          XCTAssertEqual(req.body, body)
+          XCTAssertEqual(req.header(for: HTTP.StdHeaders.contentType), contentType.value)
+          XCTAssertEqual(req.header(for: HTTP.StdHeaders.transferEncoding), "chunked")
+          res.send(statusCode: .noContent)
+        }
+      }
+    }
+
+    guard let serverURL = server.startLocal(timeout: 5.0) else {
+      XCTFail("could not start local server")
+      return
+    }
+    defer { server.stop() }
+
+    let transport = URLSessionTransport(baseURL: .init(format: serverURL.absoluteString))
+    let operation: StreamingOperation<Void, URLSessionTransport> =
+      Operation(
+        transport: transport,
+        spec: .streaming(
+          method: .post,
+          pathTemplate: "/api",
+          body: StreamingBody.bytes {
+            AsyncStream { continuation in
+              chunks.forEach { continuation.yield($0) }
+              continuation.finish()
+            }
+          },
+          contentTypes: [contentType]
+        )
+      )
+
+    try await operation.execute()
+  }
+
+  func testStreamingAsyncBytesBodyFactoryCanBeReused() async throws {
+
+    let chunks = [Data("first-".utf8), Data("second".utf8)]
+    let body = chunks.reduce(into: Data()) { $0.append($1) }
+    let contentType = try MediaType(valid: "application/x-tar")
+    let requestCount = Mutex(0)
+    let server = try RoutingHTTPServer(port: .any, localOnly: true) {
+      Path("/api") {
+        POST { req, res in
+          requestCount.withLock { $0 += 1 }
+          XCTAssertEqual(req.body, body)
+          XCTAssertEqual(req.header(for: HTTP.StdHeaders.transferEncoding), "chunked")
+          res.send(statusCode: .noContent)
+        }
+      }
+    }
+
+    guard let serverURL = server.startLocal(timeout: 5.0) else {
+      XCTFail("could not start local server")
+      return
+    }
+    defer { server.stop() }
+
+    let factoryCount = Mutex(0)
+    let transport = URLSessionTransport(baseURL: .init(format: serverURL.absoluteString))
+    let operation: StreamingOperation<Void, URLSessionTransport> =
+      Operation(
+        transport: transport,
+        spec: .streaming(
+          method: .post,
+          pathTemplate: "/api",
+          body: StreamingBody.bytes {
+            factoryCount.withLock { $0 += 1 }
+            return AsyncStream { continuation in
+              chunks.forEach { continuation.yield($0) }
+              continuation.finish()
+            }
+          },
+          contentTypes: [contentType]
+        )
+      )
+
+    try await operation.execute()
+    try await operation.execute()
+
+    XCTAssertGreaterThanOrEqual(factoryCount.withLock { $0 }, 2)
+    XCTAssertEqual(requestCount.withLock { $0 }, 2)
+  }
+
+  func testStreamingAsyncBytesBodyStartsWhenStreamOpens() async throws {
+
+    let state = TrackingByteSequence.State()
+    let contentType = try MediaType(valid: "application/x-tar")
+    let transport = URLSessionTransport(baseURL: "http://example.com")
+
+    let request = try await transport.transportRequest(
+      spec: .streaming(
+        method: .post,
+        pathTemplate: "/api",
+        body: StreamingBody.bytes {
+          TrackingByteSequence(chunks: [Data("body".utf8)], state: state)
+        },
+        contentTypes: [contentType]
+      )
+    )
+
+    try await Task.sleep(for: .milliseconds(50))
+    XCTAssertEqual(state.starts.withLock { $0 }, 0)
+
+    let stream = try XCTUnwrap(request.httpBodyStream)
+    stream.open()
+    defer { stream.close() }
+
+    try await Task.sleep(for: .milliseconds(50))
+    XCTAssertEqual(state.starts.withLock { $0 }, 1)
+  }
+
+  func testExecutesStreamingTransportRequest() async throws {
+
+    let body = Data("manual-streamed-request-body".utf8)
+    let contentType = try MediaType(valid: "application/x-tar")
+    let server = try RoutingHTTPServer(port: .any, localOnly: true) {
+      Path("/api") {
+        POST { req, res in
+          XCTAssertEqual(req.body, body)
+          XCTAssertEqual(req.header(for: HTTP.StdHeaders.contentType), contentType.value)
+          res.send(statusCode: .noContent)
+        }
+      }
+    }
+
+    guard let serverURL = server.startLocal(timeout: 5.0) else {
+      XCTFail("could not start local server")
+      return
+    }
+    defer { server.stop() }
+
+    let transport = URLSessionTransport(baseURL: .init(format: serverURL.absoluteString))
+    let request = try await transport.transportRequest(
+      spec: .streaming(
+        method: .post,
+        pathTemplate: "/api",
+        body: StreamingBody(stream: { InputStream(data: body) }),
+        contentTypes: [contentType]
+      )
+    )
+
+    let response = try await transport.transportResponse(request: request)
+
+    XCTAssertEqual(response.statusCode, 204)
+  }
+
 
   //
   // MARK: Response/Result Processing
@@ -1273,6 +1497,35 @@ class URLSessionTransportTests: XCTestCase {
     }
 
     XCTAssertNil(result)
+  }
+
+}
+
+
+private struct TrackingByteSequence: AsyncSequence, Sendable {
+
+  final class State: @unchecked Sendable {
+    let starts = Mutex(0)
+  }
+
+  typealias Element = Data
+
+  let chunks: [Data]
+  let state: State
+
+  func makeAsyncIterator() -> Iterator {
+    state.starts.withLock { $0 += 1 }
+    return Iterator(chunks: chunks.makeIterator())
+  }
+
+  struct Iterator: AsyncIteratorProtocol {
+
+    var chunks: IndexingIterator<[Data]>
+
+    mutating func next() async throws -> Data? {
+      chunks.next()
+    }
+
   }
 
 }

--- a/Tests/SundayTests/URLSessionTransportTests.swift
+++ b/Tests/SundayTests/URLSessionTransportTests.swift
@@ -277,7 +277,10 @@ class URLSessionTransportTests: XCTestCase {
     }
     defer { server.stop() }
 
-    let transport = URLSessionTransport(baseURL: .init(format: serverURL.absoluteString))
+    let transport = URLSessionTransport(
+      baseURL: .init(format: serverURL.absoluteString),
+      adapter: RebuildingRequestAdapter()
+    )
     let operation: StreamingOperation<Void, URLSessionTransport> =
       Operation(
         transport: transport,
@@ -616,6 +619,45 @@ class URLSessionTransportTests: XCTestCase {
     defer { server.stop() }
 
     let transport = URLSessionTransport(baseURL: .init(format: serverURL.absoluteString))
+    let request = try await transport.transportRequest(
+      spec: .streaming(
+        method: .post,
+        pathTemplate: "/api",
+        body: StreamingBody(stream: { InputStream(data: body) }),
+        contentTypes: [contentType]
+      )
+    )
+
+    let response = try await transport.transportResponse(request: request)
+
+    XCTAssertEqual(response.statusCode, 204)
+  }
+
+  func testExecutesStreamingTransportRequestWhenAdapterRebuildsRequest() async throws {
+
+    let body = Data("adapter-streamed-request-body".utf8)
+    let contentType = try MediaType(valid: "application/x-tar")
+    let server = try RoutingHTTPServer(port: .any, localOnly: true) {
+      Path("/api") {
+        POST { req, res in
+          XCTAssertEqual(req.body, body)
+          XCTAssertEqual(req.header(for: HTTP.StdHeaders.contentType), contentType.value)
+          XCTAssertEqual(req.header(for: "x-adapted"), "true")
+          res.send(statusCode: .noContent)
+        }
+      }
+    }
+
+    guard let serverURL = server.startLocal(timeout: 5.0) else {
+      XCTFail("could not start local server")
+      return
+    }
+    defer { server.stop() }
+
+    let transport = URLSessionTransport(
+      baseURL: .init(format: serverURL.absoluteString),
+      adapter: RebuildingRequestAdapter()
+    )
     let request = try await transport.transportRequest(
       spec: .streaming(
         method: .post,
@@ -1688,6 +1730,19 @@ class URLSessionTransportTests: XCTestCase {
 
 private enum StreamingBodyTestError: Error {
   case replayFailed
+}
+
+
+private struct RebuildingRequestAdapter: RequestAdapter {
+
+  func adapt(transport: some Transport, urlRequest: URLRequest) -> URLRequest {
+    var request = URLRequest(url: urlRequest.url!)
+    request.httpMethod = urlRequest.httpMethod
+    request.allHTTPHeaderFields = urlRequest.allHTTPHeaderFields
+    request.setValue("true", forHTTPHeaderField: "x-adapted")
+    return request
+  }
+
 }
 
 

--- a/Tests/SundayTests/URLSessionTransportTests.swift
+++ b/Tests/SundayTests/URLSessionTransportTests.swift
@@ -383,6 +383,64 @@ class URLSessionTransportTests: XCTestCase {
     XCTAssertEqual(requestCount.withLock { $0 }, 2)
   }
 
+  func testStreamingAsyncBytesBodyCanBeReplayedForTemporaryRedirect() async throws {
+
+    let chunks = [Data("redirected-".utf8), Data("stream".utf8)]
+    let body = chunks.reduce(into: Data()) { $0.append($1) }
+    let contentType = try MediaType(valid: "application/x-tar")
+    let requestCount = Mutex(0)
+    let server = try RoutingHTTPServer(port: .any, localOnly: true) {
+      Path("/redirect") {
+        POST { _, res in
+          requestCount.withLock { $0 += 1 }
+          res.send(
+            status: .temporaryRedirect,
+            headers: [HTTP.StdHeaders.location: ["/api"]],
+            body: Data()
+          )
+        }
+      }
+      Path("/api") {
+        POST { req, res in
+          requestCount.withLock { $0 += 1 }
+          XCTAssertEqual(req.body, body)
+          XCTAssertEqual(req.header(for: HTTP.StdHeaders.transferEncoding), "chunked")
+          res.send(statusCode: .noContent)
+        }
+      }
+    }
+
+    guard let serverURL = server.startLocal(timeout: 5.0) else {
+      XCTFail("could not start local server")
+      return
+    }
+    defer { server.stop() }
+
+    let factoryCount = Mutex(0)
+    let transport = URLSessionTransport(baseURL: .init(format: serverURL.absoluteString))
+    let operation: StreamingOperation<Void, URLSessionTransport> =
+      Operation(
+        transport: transport,
+        spec: .streaming(
+          method: .post,
+          pathTemplate: "/redirect",
+          body: StreamingBody.bytes {
+            factoryCount.withLock { $0 += 1 }
+            return AsyncStream { continuation in
+              chunks.forEach { continuation.yield($0) }
+              continuation.finish()
+            }
+          },
+          contentTypes: [contentType]
+        )
+      )
+
+    try await operation.execute()
+
+    XCTAssertGreaterThanOrEqual(factoryCount.withLock { $0 }, 2)
+    XCTAssertEqual(requestCount.withLock { $0 }, 2)
+  }
+
   func testStreamingAsyncBytesBodyStartsWhenStreamOpens() async throws {
 
     let state = TrackingByteSequence.State()


### PR DESCRIPTION
Summary

- Add StreamingBody and streaming OperationSpec support for URLSessionTransport.
- Execute streaming request bodies through the configured URLSession using bytes(for:) and httpBodyStream.
- Fix SundayServer chunked request parsing so terminating chunks finish requests instead of hanging.

Details

- Supports file, InputStream, and AsyncSequence<Data> streaming bodies.
- AsyncSequence<Data> streams start when the body stream opens, not when transportRequest() builds the URLRequest.
- URLSession owns transfer framing; the runtime does not manually set Content-Length or Transfer-Encoding.

Validation

- swift test --package-path . --filter URLSessionTransportTests
- swift test --package-path .